### PR TITLE
pum_bw: added static attrributes for type and park_and_ride_type

### DIFF
--- a/src/parkapi_sources/converters/pum_bw/converter.py
+++ b/src/parkapi_sources/converters/pum_bw/converter.py
@@ -68,6 +68,8 @@ class PumBwPushConverter(XlsxConverter):
 
         parking_site_dict['uid'] = f"{parking_site_dict['uid']}-{parking_site_dict['name']}"
         parking_site_dict['name'] = f"{parking_site_dict['street']} {parking_site_dict['name']}"
+        parking_site_dict['type'] = 'OFF_STREET_PARKING_GROUND'
+        parking_site_dict['park_and_ride_type'] = ['CARPOOL']
         parking_site_dict['static_data_updated_at'] = datetime.now(tz=timezone.utc).isoformat()
 
         return parking_site_dict


### PR DESCRIPTION
This PR adds the static attribute "type":  "OFF_STREET_PARKING_GROUND "and "park_and_ride_type": "CARPOOL" to the converter: Since the converter is basically for Park-und-Mitfahren (also related to Carpooling parking data) in Baden-Württemberg, and the attribute "type" is now required in the new ParkAPI version 3 sources Module.