### PR TITLE
Stricter validation

### DIFF
--- a/src/parkapi_sources/converters/bfrk_bw/base_models.py
+++ b/src/parkapi_sources/converters/bfrk_bw/base_models.py
@@ -20,8 +20,9 @@ from parkapi_sources.validators import ExcelNoneable, GermanDecimalValidator
 class BfrkBaseRowInput:
     uid: str = StringValidator()
     name: str = StringValidator()
-    lat: Decimal = GermanDecimalValidator()
-    lon: Decimal = GermanDecimalValidator()
+    # min / max are bounding box of Baden-Württemberg
+    lat: Decimal = GermanDecimalValidator(min_value=Decimal('47.5'), max_value=Decimal('49.8'))
+    lon: Decimal = GermanDecimalValidator(min_value=Decimal('7.5'), max_value=Decimal('10.5'))
     capacity: int = IntegerValidator(allow_strings=True)
     identifier_dhid: str = StringValidator()
     identifier_osm: str = StringValidator()

--- a/src/parkapi_sources/converters/neckarsulm_bike/converter.py
+++ b/src/parkapi_sources/converters/neckarsulm_bike/converter.py
@@ -31,8 +31,8 @@ class NeckarsulmBikePushConverter(CsvConverter):
         'anzahl': 'capacity',
         'lage': 'additional_name',
         'eigentuemer': 'operator_name',
-        'X': 'lat',
-        'y': 'lon',
+        'X': 'lon',
+        'y': 'lat',
     }
 
     def handle_csv_string(

--- a/src/parkapi_sources/models/parking_site_inputs.py
+++ b/src/parkapi_sources/models/parking_site_inputs.py
@@ -73,10 +73,11 @@ class StaticParkingSiteInput(BaseParkingSiteInput):
         DefaultUnset,
     )
 
-    lat: Decimal = NumericValidator(min_value=-90, max_value=90)
-    lon: Decimal = NumericValidator(min_value=-180, max_value=180)
+    # Set min/max to Europe borders
+    lat: Decimal = NumericValidator(min_value=34, max_value=72)
+    lon: Decimal = NumericValidator(min_value=-27, max_value=43)
 
-    capacity: OptionalUnsetNone[int] = Noneable(IntegerValidator(min_value=0, allow_strings=True)), DefaultUnset
+    capacity: int = Noneable(IntegerValidator(min_value=0, allow_strings=True)), DefaultUnset
     capacity_disabled: OptionalUnsetNone[int] = Noneable(IntegerValidator(min_value=0, allow_strings=True)), DefaultUnset
     capacity_woman: OptionalUnsetNone[int] = Noneable(IntegerValidator(min_value=0, allow_strings=True)), DefaultUnset
     capacity_family: OptionalUnsetNone[int] = Noneable(IntegerValidator(min_value=0, allow_strings=True)), DefaultUnset

--- a/tests/converters/bfrk_bw_test.py
+++ b/tests/converters/bfrk_bw_test.py
@@ -25,9 +25,8 @@ class BfrkCarPullConverterTest:
 
         static_parking_site_inputs, import_parking_site_exceptions = bfrk_car_push_converter.handle_csv_string(bfrk_car_data)
 
-        assert len(static_parking_site_inputs) > len(
-            import_parking_site_exceptions
-        ), 'There should be more valid then invalid parking sites'
+        assert len(static_parking_site_inputs) == 1555
+        assert len(import_parking_site_exceptions) == 0
 
         validate_static_parking_site_inputs(static_parking_site_inputs)
 
@@ -45,8 +44,7 @@ class BfrkBikePullConverterTest:
 
         static_parking_site_inputs, import_parking_site_exceptions = bfrk_bike_push_converter.handle_csv_string(bfrk_bike_data)
 
-        assert len(static_parking_site_inputs) > len(
-            import_parking_site_exceptions
-        ), 'There should be more valid then invalid parking sites'
+        assert len(static_parking_site_inputs) == 2000
+        assert len(import_parking_site_exceptions) == 1  # One failure due invalid coordinate
 
         validate_static_parking_site_inputs(static_parking_site_inputs)

--- a/tests/converters/neckarsulm_bike_test.py
+++ b/tests/converters/neckarsulm_bike_test.py
@@ -25,8 +25,7 @@ class NeckarsulmPushConverterTest:
 
         static_parking_site_inputs, import_parking_site_exceptions = neckarsulm_bike_push_converter.handle_csv_string(neckarsulm_data)
 
-        assert len(static_parking_site_inputs) > len(
-            import_parking_site_exceptions
-        ), 'There should be more valid then invalid parking sites'
+        assert len(static_parking_site_inputs) == 235
+        assert len(import_parking_site_exceptions) == 1
 
         validate_static_parking_site_inputs(static_parking_site_inputs)


### PR DESCRIPTION
Does a stricter validation: requires `capacity`, limits lat/lon to Europe. Fixes issues with BFRK (one broken dataset) and Neckarsulm bike (lat/lon mixup).