### PR TITLE
APCOA Converter: Fixes the OSM opening_hours (24:00)

### DIFF
--- a/src/parkapi_sources/converters/apcoa/mapper.py
+++ b/src/parkapi_sources/converters/apcoa/mapper.py
@@ -44,9 +44,6 @@ class ApcoaMapper:
         if apcoa_input.Address.Street and apcoa_input.Address.Zip and apcoa_input.Address.City:
             static_parking_site_input.address = f'{apcoa_input.Address.Street}, {apcoa_input.Address.Zip} {apcoa_input.Address.City}'
 
-        if apcoa_input.CarParkPhotoURLs:
-            static_parking_site_input.photo_url = apcoa_input.CarParkPhotoURLs.CarparkPhotoURL1
-
         if apcoa_input.IndicativeTariff.MinValue or apcoa_input.IndicativeTariff.MaxValue:
             static_parking_site_input.has_fee = True
 

--- a/src/parkapi_sources/converters/apcoa/mapper.py
+++ b/src/parkapi_sources/converters/apcoa/mapper.py
@@ -44,6 +44,9 @@ class ApcoaMapper:
         if apcoa_input.Address.Street and apcoa_input.Address.Zip and apcoa_input.Address.City:
             static_parking_site_input.address = f'{apcoa_input.Address.Street}, {apcoa_input.Address.Zip} {apcoa_input.Address.City}'
 
+        if apcoa_input.CarParkPhotoURLs:
+            static_parking_site_input.photo_url = apcoa_input.CarParkPhotoURLs.CarparkPhotoURL1
+
         if apcoa_input.IndicativeTariff.MinValue or apcoa_input.IndicativeTariff.MaxValue:
             static_parking_site_input.has_fee = True
 

--- a/src/parkapi_sources/converters/apcoa/validators.py
+++ b/src/parkapi_sources/converters/apcoa/validators.py
@@ -156,7 +156,6 @@ class ApcoaParkingSiteInput:
     CarparkLongName: Optional[str] = Noneable(StringValidator())
     CarparkShortName: Optional[str] = Noneable(StringValidator())
     CarParkWebsiteURL: Optional[str] = Noneable(UrlValidator())
-    CarParkPhotoURLs: Optional[ApcoaCarparkPhotoURLInput] = Noneable(DataclassValidator(ApcoaCarparkPhotoURLInput))
     CarparkType: ApcoaCarparkTypeNameInput = DataclassValidator(ApcoaCarparkTypeNameInput)
     Address: ApcoaAdressInput = DataclassValidator(ApcoaAdressInput)
     NavigationLocations: list[ApcoaNavigationLocationsInput] = ListValidator(DataclassValidator(ApcoaNavigationLocationsInput))
@@ -190,7 +189,7 @@ class ApcoaParkingSiteInput:
                 continue
 
             # OSM has times without spaces, so we remove spaces
-            opening_time = opening_hours_input.OpeningTimes.replace(' ', '')
+            opening_time = opening_hours_input.OpeningTimes.replace(' ', '').replace('-00:00', '-24:00')
 
             # If it's open all day, add it to our 24/7 check counter, and we change opening_time to the OSM format
             if opening_hours_input.OpeningTimes == '00:00 - 00:00':

--- a/src/parkapi_sources/converters/apcoa/validators.py
+++ b/src/parkapi_sources/converters/apcoa/validators.py
@@ -156,6 +156,7 @@ class ApcoaParkingSiteInput:
     CarparkLongName: Optional[str] = Noneable(StringValidator())
     CarparkShortName: Optional[str] = Noneable(StringValidator())
     CarParkWebsiteURL: Optional[str] = Noneable(UrlValidator())
+    CarParkPhotoURLs: Optional[ApcoaCarparkPhotoURLInput] = Noneable(DataclassValidator(ApcoaCarparkPhotoURLInput))
     CarparkType: ApcoaCarparkTypeNameInput = DataclassValidator(ApcoaCarparkTypeNameInput)
     Address: ApcoaAdressInput = DataclassValidator(ApcoaAdressInput)
     NavigationLocations: list[ApcoaNavigationLocationsInput] = ListValidator(DataclassValidator(ApcoaNavigationLocationsInput))

--- a/tests/converters/apcoa_test.py
+++ b/tests/converters/apcoa_test.py
@@ -295,6 +295,7 @@ class ApcoaParkingSiteInputTest:
             CarparkLongName=None,
             CarparkShortName=None,
             CarParkWebsiteURL=None,
+            CarParkPhotoURLs=None,
             CarparkType=ApcoaCarparkTypeNameInput(
                 Name='example name',
             ),

--- a/tests/converters/apcoa_test.py
+++ b/tests/converters/apcoa_test.py
@@ -253,6 +253,40 @@ class ApcoaParkingSiteInputTest:
                 ],
                 'Mo-Fr 00:00-24:00',
             ),
+            # Test for different times ending with 00:00 instead of 24:00
+            (
+                [
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.MONDAY,
+                        OpeningTimes='05:00 - 00:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.TUESDAY,
+                        OpeningTimes='05:00 - 00:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.WEDNESDAY,
+                        OpeningTimes='05:00 - 00:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.THURSDAY,
+                        OpeningTimes='05:00 - 02:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.FRIDAY,
+                        OpeningTimes='05:00 - 02:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.SATURDAY,
+                        OpeningTimes='05:00 - 02:00',
+                    ),
+                    ApcoaOpeningHoursInput(
+                        Weekday=ApcoaOpeningHoursWeekday.SUNDAY,
+                        OpeningTimes='05:00 - 02:00',
+                    ),
+                ],
+                'Mo 05:00-24:00; Tu 05:00-24:00; We 05:00-24:00; Th 05:00-02:00; Fr 05:00-02:00; Sa 05:00-02:00; Su 05:00-02:00',
+            ),
         ],
     )
     def test_get_osm_opening_hours(opening_times: list[ApcoaOpeningHoursInput], osm_opening_hours: str):
@@ -261,7 +295,6 @@ class ApcoaParkingSiteInputTest:
             CarparkLongName=None,
             CarparkShortName=None,
             CarParkWebsiteURL=None,
-            CarParkPhotoURLs=None,
             CarparkType=ApcoaCarparkTypeNameInput(
                 Name='example name',
             ),


### PR DESCRIPTION
This PR fixes the APCOA ```opening_hours``` ending with 00:00 by replacing it with OSM Format 24:00 (e.g. Parking place with UID: ```20236``` with opening times - ```Mo 05:00-00:00; Tu 05:00-00:00; We 05:00-00:00; Th 05:00-02:00; Fr 05:00-02:00; Sa 05:00-02:00; Su 05:00-02:00)``` and adding a test script to ensure all opening times conforms with OSM Format. 

In addition the ```photo_url``` field and values were removed from the dataset, because the parking place photos ```CarParkPhotoURLs``` of APCOA data contain pictures in Blob Format ([Example parking](https://apcoatx.blob.core.windows.net/mdm/fc44f33f-d70f-44f1-8418-ab1640fc39dc)). The photos does not load directly with the URL. To view the photo, it must be downloaded and opened with a photo app or photo software, which does not conform with purpose of the ```photo_url``` data model in the ParkAPI.

### Updated:
```photo_url``` was added back since the values of ```CarParkPhotoURLs``` in APCOA Data are valid JPEG and can work perfectly for data users in an application or in HTML tag.