### PR TITLE
set opening status to none if unset

### DIFF
--- a/src/parkapi_sources/converters/bietigheim_bissingen/models.py
+++ b/src/parkapi_sources/converters/bietigheim_bissingen/models.py
@@ -19,7 +19,7 @@ class BietigheimBissingenOpeningStatus(Enum):
     OPEN = 'Geöffnet'
     CLOSED = 'Geschlossen'
 
-    def to_realtime_opening_status(self) -> OpeningStatus:
+    def to_realtime_opening_status(self) -> OpeningStatus | None:
         return {
             self.OPEN: OpeningStatus.OPEN,
             self.CLOSED: OpeningStatus.CLOSED,

--- a/src/parkapi_sources/converters/bietigheim_bissingen/models.py
+++ b/src/parkapi_sources/converters/bietigheim_bissingen/models.py
@@ -23,7 +23,7 @@ class BietigheimBissingenOpeningStatus(Enum):
         return {
             self.OPEN: OpeningStatus.OPEN,
             self.CLOSED: OpeningStatus.CLOSED,
-        }.get(self, OpeningStatus.UNKNOWN)
+        }.get(self)
 
 
 @validataclass

--- a/src/parkapi_sources/converters/heidelberg/models.py
+++ b/src/parkapi_sources/converters/heidelberg/models.py
@@ -64,7 +64,7 @@ class HeidelbergParkingSiteStatus(Enum):
     BROKEN = 'Stoerung'
     UNKNOWN = '0'
 
-    def to_opening_status(self) -> OpeningStatus:
+    def to_opening_status(self) -> OpeningStatus | None:
         return {
             self.OPEN: OpeningStatus.OPEN,
             self.OPEN_DE: OpeningStatus.OPEN,
@@ -72,7 +72,7 @@ class HeidelbergParkingSiteStatus(Enum):
             self.CLOSED_DE: OpeningStatus.CLOSED,
             self.UNKNOWN: OpeningStatus.UNKNOWN,
             self.BROKEN: OpeningStatus.CLOSED,
-        }.get(self, OpeningStatus.UNKNOWN)
+        }.get(self)
 
 
 class HeidelbergParkingType(Enum):

--- a/src/parkapi_sources/converters/herrenberg/models.py
+++ b/src/parkapi_sources/converters/herrenberg/models.py
@@ -66,13 +66,13 @@ class HerrenbergState(Enum):
     CLOSED = 'closed'
     UNKNOWN = 'unknown'
 
-    def to_opening_status(self) -> OpeningStatus:
+    def to_opening_status(self) -> OpeningStatus | None:
         return {
             self.OPEN: OpeningStatus.OPEN,
             self.CLOSED: OpeningStatus.CLOSED,
             self.MANY: OpeningStatus.OPEN,
             self.FULL: OpeningStatus.OPEN,
-        }.get(self, OpeningStatus.UNKNOWN)
+        }.get(self)
 
 
 @validataclass

--- a/src/parkapi_sources/converters/karlsruhe/models.py
+++ b/src/parkapi_sources/converters/karlsruhe/models.py
@@ -33,11 +33,11 @@ class KarlsruheOpeningStatus(Enum):
     OPEN = 'F'
     CLOSED = 'T'
 
-    def to_opening_status(self) -> OpeningStatus:
+    def to_opening_status(self) -> OpeningStatus | None:
         return {
             self.OPEN: OpeningStatus.OPEN,
             self.CLOSED: OpeningStatus.CLOSED,
-        }.get(self, OpeningStatus.UNKNOWN)
+        }.get(self)
 
 
 @validataclass
@@ -94,7 +94,7 @@ class KarlsruheFeatureInput:
             return None
 
         if self.properties.geschlossen is None:
-            opening_status = OpeningStatus.UNKNOWN
+            opening_status = None
         else:
             opening_status = self.properties.geschlossen.to_opening_status()
 

--- a/src/parkapi_sources/models/parking_site_inputs.py
+++ b/src/parkapi_sources/models/parking_site_inputs.py
@@ -137,10 +137,7 @@ class RealtimeParkingSiteInput(BaseParkingSiteInput):
         target_timezone=timezone.utc,
         discard_milliseconds=True,
     )
-    realtime_opening_status: OptionalUnsetNone[OpeningStatus] = (
-        Noneable(EnumValidator(OpeningStatus), default=OpeningStatus.UNKNOWN),
-        Default(OpeningStatus.UNKNOWN),
-    )
+    realtime_opening_status: OptionalUnsetNone[OpeningStatus] = Noneable(EnumValidator(OpeningStatus)), Default(None)
     realtime_capacity: OptionalUnsetNone[int] = (
         Noneable(IntegerValidator(min_value=0, allow_strings=True)),
         DefaultUnset,


### PR DESCRIPTION
Clearifies the opening status: set to None if permanently no data available, set to UNKNOWN when there is data in general, but not now.