### PR TITLE
 opendata_swiss: change to new source_url

### DIFF
--- a/src/parkapi_sources/converters/opendata_swiss/converter.py
+++ b/src/parkapi_sources/converters/opendata_swiss/converter.py
@@ -21,8 +21,8 @@ class OpenDataSwissPullConverter(PullConverter):
     source_info = SourceInfo(
         uid='opendata_swiss',
         name='Open-Data-Plattform öV Schweiz (opentransport.swiss)',
-        public_url='https://opentransportdata.swiss/de/dataset/parking-facilities',
-        source_url='https://opentransportdata.swiss/de/dataset/parking-facilities/permalink',
+        public_url='https://data.opentransportdata.swiss/dataset/parking-facilities',
+        source_url='https://data.opentransportdata.swiss/dataset/parking-facilities/permalink',
         timezone='Europe/Berlin',
         attribution_contributor='Schweizerische Bundesbahnen (SBB) AG',
         has_realtime_data=False,

--- a/src/parkapi_sources/converters/opendata_swiss/converter.py
+++ b/src/parkapi_sources/converters/opendata_swiss/converter.py
@@ -21,8 +21,8 @@ class OpenDataSwissPullConverter(PullConverter):
     source_info = SourceInfo(
         uid='opendata_swiss',
         name='Open-Data-Plattform öV Schweiz (opentransport.swiss)',
-        public_url='https://data.opentransportdata.swiss/dataset/parking-facilities',
-        source_url='https://data.opentransportdata.swiss/dataset/parking-facilities/permalink',
+        public_url='https://data.opentransportdata.swiss/de/dataset/parking-facilities',
+        source_url='https://data.opentransportdata.swiss/de/dataset/parking-facilities/permalink',
         timezone='Europe/Berlin',
         attribution_contributor='Schweizerische Bundesbahnen (SBB) AG',
         has_realtime_data=False,

--- a/tests/converters/data/opendata_swiss.json
+++ b/tests/converters/data/opendata_swiss.json
@@ -25,7 +25,7 @@
         "pricingModel": {
           "minimumDuration": 15,
           "maximumDuration": 1440,
-          "maximumDayPrice": null,
+          "maximumDayPrice": 500,
           "viableIncrement": 15,
           "priceSegments": [
             {
@@ -35,10 +35,6 @@
             {
               "startingFrom": 15,
               "price": 25
-            },
-            {
-              "startingFrom": 300,
-              "price": 0
             }
           ],
           "monthlyTicketPrice": 5000,
@@ -179,8 +175,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.795317621390852,
-          47.445740227553564
+          8.79700215305567,
+          47.444799770043645
         ]
       },
       "properties": {
@@ -195,14 +191,18 @@
           "postalCode": "8486"
         },
         "pricingModel": {
-          "minimumDuration": 60,
+          "minimumDuration": 15,
           "maximumDuration": 10080,
           "maximumDayPrice": 400,
-          "viableIncrement": 60,
+          "viableIncrement": 15,
           "priceSegments": [
             {
               "startingFrom": 0,
-              "price": 100
+              "price": 0
+            },
+            {
+              "startingFrom": 15,
+              "price": 25
             }
           ],
           "monthlyTicketPrice": 4000,
@@ -230,7 +230,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 11
+            "total": 15
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -523,6 +523,349 @@
     },
     {
       "type": "Feature",
+      "id": "64813559-897a-490f-8f4c-c18857f6bf05",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.551497764907664,
+          47.048320659113976
+        ]
+      },
+      "properties": {
+        "uic": 8505004,
+        "didokId": "05004",
+        "operator": "SBB",
+        "displayName": "Arth-Goldau",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 6",
+          "city": "Arth-Goldau",
+          "postalCode": "6410"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "64"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 90
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die 90 Parkplätze befinden sich an der Güterstrasse (Adresse Navigationsgeräte: Güterstrasse 6, 6410 Goldau).\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The 90 parking spaces are located on Güterstrasse (sat nav address: Güterstrasse 6, 6410 Goldau, Switzerland).\r\nThe parking meter is retired. But the P+Rail app can do much more.",
+          "it": "I 90 parcheggi si trovano in Güterstrasse (indirizzo per navigatore: Güterstrasse 6, 6410 Goldau).\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Les 90 places de stationnement se trouvent sur la Güterstrasse (adresse à indiquer dans les systèmes de navigation: Güterstrasse 6, 6410 Goldau).\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "42ff768c-321a-40c0-8b9b-8ea04ee366d6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.047648173769746,
+          47.356029732345284
+        ]
+      },
+      "properties": {
+        "uic": 8502102,
+        "didokId": "02102",
+        "operator": "SBB",
+        "displayName": "Oberentfelden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 1",
+          "city": "Oberentfelden",
+          "postalCode": "5036"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "247"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 25
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "0b4b76e9-9d98-4cba-870e-483bf31b1ba7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.571312240854168,
+          47.32386165741721
+        ]
+      },
+      "properties": {
+        "uic": 8509400,
+        "didokId": "09400",
+        "operator": "SBB",
+        "displayName": "Oberriet",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 6",
+          "city": "Oberriet",
+          "postalCode": "9463"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "76"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ad150e60-5b40-4c29-bf31-cba4da4d1277",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.214208912851312,
+          47.40689821522341
+        ]
+      },
+      "properties": {
+        "uic": 8502105,
+        "didokId": "02105",
+        "operator": "SBB",
+        "displayName": "Othmarsingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 31",
+          "city": "Othmarsingen",
+          "postalCode": "5504"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "441"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 60
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "8838b5c9-1370-4627-9b7e-55fc072640f2",
       "geometry": {
         "type": "Point",
@@ -777,6 +1120,175 @@
     },
     {
       "type": "Feature",
+      "id": "d09293c1-5cdf-415a-9a5b-bdc72d6e06e1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.591587468333644,
+          47.465977520560884
+        ]
+      },
+      "properties": {
+        "uic": 8506313,
+        "didokId": "06313",
+        "operator": "SBB",
+        "displayName": "Rheineck",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 10",
+          "city": "Rheineck",
+          "postalCode": "9424"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "36"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 107
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d159975c-c844-4c5d-9895-814dbc161cee",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.790642159795823,
+          47.550883183879186
+        ]
+      },
+      "properties": {
+        "uic": 8500301,
+        "didokId": "00301",
+        "operator": "SBB",
+        "displayName": "Rheinfelden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Imbissstand Bahnhofareal 2",
+          "city": "Rheinfelden",
+          "postalCode": "4310"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "394"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 47
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.   ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more.   ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.   ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.   "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "34a541b7-8137-422a-9853-f87832e18b69",
       "geometry": {
         "type": "Point",
@@ -935,6 +1447,180 @@
           }
         ],
         "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "810a1380-522e-48f5-a150-f9c2faa39f9b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.78964569361515,
+          47.53551146007607
+        ]
+      },
+      "properties": {
+        "uic": 8506018,
+        "didokId": "06018",
+        "operator": "SBB",
+        "displayName": "Rickenbach-Attikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Stationsstrasse 2",
+          "city": "Rickenbach-Attikon",
+          "postalCode": "8545"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "122"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 61
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "78475af2-efec-4cca-af30-c23082e74a7b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.379630214923104,
+          47.5670023260876
+        ]
+      },
+      "properties": {
+        "uic": 8506121,
+        "didokId": "06121",
+        "operator": "SBB",
+        "displayName": "Romanshorn",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bankstrasse 6",
+          "city": "Romanshorn",
+          "postalCode": "8590"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "2"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 99
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -1110,6 +1796,180 @@
     },
     {
       "type": "Feature",
+      "id": "21527d51-0b18-44c4-8ebf-54109ed2ab6c",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.502453041982415,
+          47.477737682083976
+        ]
+      },
+      "properties": {
+        "uic": 8506311,
+        "didokId": "06311",
+        "operator": "SBB",
+        "displayName": "Rorschach",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Churerstrasse 23",
+          "city": "Rorschach",
+          "postalCode": "9400"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "35"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 55
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "b2df3aea-89b7-4c6d-964a-6324afc62b28",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.062773662104932,
+          46.78278664317938
+        ]
+      },
+      "properties": {
+        "uic": 8504028,
+        "didokId": "04028",
+        "operator": "SBB",
+        "displayName": "Rosé",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Route de Rosé 49",
+          "city": "Rosé (Avry)",
+          "postalCode": "1754"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 300,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 3000,
+          "yearlyTicketPrice": 30000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "268"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "4dc820be-05b6-4e57-af8b-bd419e66a10a",
       "geometry": {
         "type": "Point",
@@ -1181,6 +2041,861 @@
           }
         ],
         "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "60cab5e8-8e01-46d2-8822-15fbeb737d2a",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.248016185925136,
+          47.08884837628276
+        ]
+      },
+      "properties": {
+        "uic": 8502020,
+        "didokId": "02020",
+        "operator": "SBB",
+        "displayName": "Rothenburg Station",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Hasenmoosstrasse 9",
+          "city": "Rothenburg (Station)",
+          "postalCode": "6023"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "210"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 17
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten entfallen diverse P+Rail-Parkplätze bis August 2025. Die Parkuhr ist in Pension. \nIhre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.\nDue to construction work, various P+Rail car parks will be closed until Ausgust 2025.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.\nA causa dei lavori di costruzione, diversi parcheggi P+Rail saranno chiusi fino ad agosto 2025.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.\nEn raison de travaux, plusieurs parkings P+Rail seront supprimés jusqu'en août 2025."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "8d4c0d6e-e075-4e59-bbd9-3a0bf323fc8c",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.532246779006671,
+          47.45413902106405
+        ]
+      },
+      "properties": {
+        "uic": 8503311,
+        "didokId": "03311",
+        "operator": "SBB",
+        "displayName": "Rümlang",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 10",
+          "city": "Rümlang",
+          "postalCode": "8153"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "223"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 77
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ea4af3b4-0a44-40ae-bde7-33c95c042e32",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.984826476284248,
+          47.32171647922929
+        ]
+      },
+      "properties": {
+        "uic": 8502100,
+        "didokId": "02100",
+        "operator": "SBB",
+        "displayName": "Safenwil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 1",
+          "city": "Safenwil",
+          "postalCode": "5745"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "434"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 15
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e0ee041d-bf36-429a-91c7-c686dbc6d6c6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.853791330831234,
+          47.395072351158404
+        ]
+      },
+      "properties": {
+        "uic": 8506009,
+        "didokId": "06009",
+        "operator": "SBB",
+        "displayName": "Saland",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Tösstalstrasse 133",
+          "city": "Saland (Bauma)",
+          "postalCode": "8493"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "379"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c4774821-af44-47ce-a989-39ce3fed53fc",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.806946162611519,
+          46.13511979178838
+        ]
+      },
+      "properties": {
+        "uic": 8505407,
+        "didokId": "05407",
+        "operator": "SBB",
+        "displayName": "San Nazzaro (Gambarogno)",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Via Cantonale 60",
+          "city": "San Nazzaro (Gambarogno)",
+          "postalCode": "6575"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "102"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 5
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "0bd599da-516e-4320-b0dc-8b65b015ee3e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.144023268543906,
+          47.03784821604149
+        ]
+      },
+      "properties": {
+        "uic": 8508217,
+        "didokId": "08217",
+        "operator": "SBB",
+        "displayName": "Schachen LU",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 7",
+          "city": "Schachen LU (Werthenstein)",
+          "postalCode": "6105"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "356"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ad68b13d-3969-45c4-94b2-ea32bd4e8885",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.167245213529462,
+          47.45150459453097
+        ]
+      },
+      "properties": {
+        "uic": 8502116,
+        "didokId": "02116",
+        "operator": "SBB",
+        "displayName": "Schinznach Bad",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 33",
+          "city": "Schinznach Bad",
+          "postalCode": "5116"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "445"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 6
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "576aeffa-b19e-4939-93d0-a7367e48a842",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.687154627644174,
+          47.67939584553593
+        ]
+      },
+      "properties": {
+        "uic": 8503427,
+        "didokId": "03427",
+        "operator": "SBB",
+        "displayName": "Schlatt",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Diessenhoferstrasse 1",
+          "city": "Schlatt",
+          "postalCode": "8252"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "412"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e7525972-ca91-48ba-8b6c-2ebf1ecca848",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.77100620873358,
+          47.666321822100244
+        ]
+      },
+      "properties": {
+        "uic": 8503429,
+        "didokId": "03429",
+        "operator": "SBB",
+        "displayName": "Schlattingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 6",
+          "city": "Basadingen-Schlattingen",
+          "postalCode": "8255"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "414"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 5
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e864361f-9082-47e2-b016-60402a11776f",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.255304652467356,
+          46.86245519884059
+        ]
+      },
+      "properties": {
+        "uic": 8504102,
+        "didokId": "04102",
+        "operator": "SBB",
+        "displayName": "Schmitten",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Mülitalstrasse 3",
+          "city": "Schmitten",
+          "postalCode": "3185"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "298"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 99
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -1267,6 +2982,175 @@
           "en": "From 13.03.2025 to 31.03.2025, the three car parks 34, 35 and 36 will not be available due to construction work.",
           "it": "Dal 13.03.2025 al 31.03.2025, i tre parcheggi 34, 35 e 36 non saranno disponibili a causa di lavori di costruzione.",
           "fr": "Du 13.03.2025 au 31.03.2025, les trois parkings 34, 35 et 36 ne seront pas disponibles en raison de travaux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "73c231d0-3865-4a80-b656-672e76dc57a3",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.387038376356803,
+          47.0417500558629
+        ]
+      },
+      "properties": {
+        "uic": 8504412,
+        "didokId": "04412",
+        "operator": "SBB",
+        "displayName": "Schüpfen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bernstrasse 16",
+          "city": "Schüpfen",
+          "postalCode": "3054"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "48"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 54
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "7b25f83d-33a2-49ad-b20b-445e2074f3fd",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.197552785330762,
+          47.11598756796258
+        ]
+      },
+      "properties": {
+        "uic": 8502009,
+        "didokId": "02009",
+        "operator": "SBB",
+        "displayName": "Sempach-Neuenkirch",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 23",
+          "city": "Sempach-Neuenkirch",
+          "postalCode": "6203"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "207"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 49
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -1849,7 +3733,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 2
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -2470,6 +4354,93 @@
     },
     {
       "type": "Feature",
+      "id": "cfe65cc9-ef90-4f4a-a499-36dc714bbb65",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.49389754898408,
+          47.125001226299716
+        ]
+      },
+      "properties": {
+        "uic": 8509406,
+        "didokId": "09406",
+        "operator": "SBB",
+        "displayName": "Sevelen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Nordstrasse",
+          "city": "Sevelen",
+          "postalCode": "9475"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "79"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 6
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "e13d2788-80fa-4b81-addc-9a8ff3202503",
       "geometry": {
         "type": "Point",
@@ -2529,7 +4500,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 4
+            "total": 5
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -3681,6 +5652,88 @@
     },
     {
       "type": "Feature",
+      "id": "1a354adc-047b-4e25-b3b5-5ae5f0f0d982",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.903226688910442,
+          47.18265940889545
+        ]
+      },
+      "properties": {
+        "uic": 8503221,
+        "didokId": "03221",
+        "operator": "SBB",
+        "displayName": "Siebnen-Wangen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 3",
+          "city": "Siebnen-Wangen",
+          "postalCode": "8854"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "168"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 165
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "80b76b2c-d28a-4721-88e2-4b7cde553489",
       "geometry": {
         "type": "Point",
@@ -4095,6 +6148,175 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "49b16773-ddf5-4a2d-a82a-93f20910af1e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.724986402973297,
+          46.91929030522081
+        ]
+      },
+      "properties": {
+        "uic": 8508205,
+        "didokId": "08205",
+        "operator": "SBB",
+        "displayName": "Signau",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 3",
+          "city": "Signau",
+          "postalCode": "3534"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "354"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "a3dd5a87-d88c-45f8-8017-ff42a5edbd9f",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.397646976494833,
+          47.18781593539478
+        ]
+      },
+      "properties": {
+        "uic": 8502218,
+        "didokId": "02218",
+        "operator": "SBB",
+        "displayName": "Sins",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 30",
+          "city": "Sins",
+          "postalCode": "5643"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "450"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 22
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -4536,6 +6758,93 @@
     },
     {
       "type": "Feature",
+      "id": "b283db05-876b-463a-9261-f6a1ba8c5485",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.002042086880742,
+          47.462465394256846
+        ]
+      },
+      "properties": {
+        "uic": 8506010,
+        "didokId": "06010",
+        "operator": "SBB",
+        "displayName": "Sirnach",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Wilerstrasse 14",
+          "city": "Sirnach",
+          "postalCode": "8370"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "116"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 31
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "913b36a4-137d-40f5-b15d-d33d9e39c1f6",
       "geometry": {
         "type": "Point",
@@ -4874,6 +7183,93 @@
     },
     {
       "type": "Feature",
+      "id": "7e56dd5c-320b-4fa7-9a5d-efbc33c82bec",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.074281855768314,
+          47.18012405162308
+        ]
+      },
+      "properties": {
+        "uic": 8502010,
+        "didokId": "02010",
+        "operator": "SBB",
+        "displayName": "St. Erhard-Knutwil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhöfli 5",
+          "city": "St. Erhard-Knutwil",
+          "postalCode": "6212"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "431"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "c8c7f6ca-150c-4f55-9f6c-8b77dd4504a8",
       "geometry": {
         "type": "Point",
@@ -5123,6 +7519,93 @@
           "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "357be87f-ed9b-4aa2-90fd-1854158172d6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.394243565708434,
+          47.43456462233892
+        ]
+      },
+      "properties": {
+        "uic": 8506303,
+        "didokId": "06303",
+        "operator": "SBB",
+        "displayName": "St. Gallen St. Fiden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Untere Lindentalstrasse 6",
+          "city": "St. Fiden (St. Gallen)",
+          "postalCode": "9000 "
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "31"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 24
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.   Zusätzlich zu den 30 Parkplätzen am Bahnhof stehen auf der Lindentalstrasse 9 Plätze zur Verfügung, wo Fahrzeuge mit SBB Parkkarte abgestellt werden können.     Achtung: Während der Olma stehen diese 9 Plätze nicht zur Verfügung.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more. In addition to the 30 parking spaces at the station, there are also 9 spaces on Lindentalstrasse where vehicles with SBB parking passes can be parked.     Please note: these 9 spaces will not be available during OLMA.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.  Oltre ai 30 parcheggi in stazione, sono disponibili 9 parcheggi sulla Lindentalstrasse per veicoli con tessera di parcheggio FFS.     Attenzione: durante l'Olma questi 9 parcheggi non sono disponibili.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  Outre les 30 places du parking de la gare, 9 autres places sont disponibles dans la Lindentalstrasse, où il est possible de se garer avec la carte de stationnement CFF.     Attention: Ces 9 places ne sont pas disponibles pendant l’Oma."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -5385,6 +7868,88 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "87d53212-6500-40d6-9b10-5f8f5c39dfab",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.854361185835996,
+          47.65656878182456
+        ]
+      },
+      "properties": {
+        "uic": 8506139,
+        "didokId": "06139",
+        "operator": "SBB",
+        "displayName": "Stein am Rhein",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 13",
+          "city": "Stein am Rhein",
+          "postalCode": "8260"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "8"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 53
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -5716,6 +8281,88 @@
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
             "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c4e06053-d433-4595-bec4-b9a449823588",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.446894992871414,
+          47.48982957313251
+        ]
+      },
+      "properties": {
+        "uic": 8503316,
+        "didokId": "03316",
+        "operator": "SBB",
+        "displayName": "Steinmaur",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Steinmaur",
+          "postalCode": "8162"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "227"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 39
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
           },
           {
             "categoryType": "WITH_CHARGING_STATION",
@@ -6071,6 +8718,93 @@
     },
     {
       "type": "Feature",
+      "id": "5d1fa595-78db-44f7-863a-0834a98c18a5",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.33903945217074,
+          47.0580445203619
+        ]
+      },
+      "properties": {
+        "uic": 8504413,
+        "didokId": "04413",
+        "operator": "SBB",
+        "displayName": "Suberg-Grossaffoltern",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bernstrasse 67",
+          "city": "Suberg-Grossaffoltern",
+          "postalCode": "3262"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "49"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 72
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "e511d897-336a-45a7-b32b-989934a51846",
       "geometry": {
         "type": "Point",
@@ -6309,6 +9043,93 @@
           }
         ],
         "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "6e3beb6b-cb02-4143-80cd-5b763fdbf383",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.130545294604948,
+          47.65986821825864
+        ]
+      },
+      "properties": {
+        "uic": 8506132,
+        "didokId": "06132",
+        "operator": "SBB",
+        "displayName": "Tägerwilen-Gottlieben",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnstrasse 1",
+          "city": "Tägerwilen-Gottlieben",
+          "postalCode": "8274"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 3000,
+          "yearlyTicketPrice": 30000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "349"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 4
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -6966,7 +9787,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 0
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -13236,93 +16057,6 @@
     },
     {
       "type": "Feature",
-      "id": "357be87f-ed9b-4aa2-90fd-1854158172d6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.394243565708434,
-          47.43456462233892
-        ]
-      },
-      "properties": {
-        "uic": 8506303,
-        "didokId": "06303",
-        "operator": "SBB",
-        "displayName": "St. Gallen St. Fiden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Untere Lindentalstrasse 6",
-          "city": "St. Fiden (St. Gallen)",
-          "postalCode": "9000 "
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "31"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 24
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.   Zusätzlich zu den 30 Parkplätzen am Bahnhof stehen auf der Lindentalstrasse 9 Plätze zur Verfügung, wo Fahrzeuge mit SBB Parkkarte abgestellt werden können.     Achtung: Während der Olma stehen diese 9 Plätze nicht zur Verfügung.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more. In addition to the 30 parking spaces at the station, there are also 9 spaces on Lindentalstrasse where vehicles with SBB parking passes can be parked.     Please note: these 9 spaces will not be available during OLMA.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.  Oltre ai 30 parcheggi in stazione, sono disponibili 9 parcheggi sulla Lindentalstrasse per veicoli con tessera di parcheggio FFS.     Attenzione: durante l'Olma questi 9 parcheggi non sono disponibili.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  Outre les 30 places du parking de la gare, 9 autres places sont disponibles dans la Lindentalstrasse, où il est possible de se garer avec la carte de stationnement CFF.     Attention: Ces 9 places ne sont pas disponibles pendant l’Oma."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "6abb1792-a44a-4c0b-9ee0-0d8e9b5cb2f3",
       "geometry": {
         "type": "Point",
@@ -14004,88 +16738,6 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ad150e60-5b40-4c29-bf31-cba4da4d1277",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.214208912851312,
-          47.40689821522341
-        ]
-      },
-      "properties": {
-        "uic": 8502105,
-        "didokId": "02105",
-        "operator": "SBB",
-        "displayName": "Othmarsingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 31",
-          "city": "Othmarsingen",
-          "postalCode": "5504"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "441"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 60
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -20415,93 +23067,6 @@
     },
     {
       "type": "Feature",
-      "id": "cfe65cc9-ef90-4f4a-a499-36dc714bbb65",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.49389754898408,
-          47.125001226299716
-        ]
-      },
-      "properties": {
-        "uic": 8509406,
-        "didokId": "09406",
-        "operator": "SBB",
-        "displayName": "Sevelen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Nordstrasse",
-          "city": "Sevelen",
-          "postalCode": "9475"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "79"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 6
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "92ca4f7d-3083-4277-9efd-091117125c99",
       "geometry": {
         "type": "Point",
@@ -21438,93 +24003,6 @@
     },
     {
       "type": "Feature",
-      "id": "60cab5e8-8e01-46d2-8822-15fbeb737d2a",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.248016185925136,
-          47.08884837628276
-        ]
-      },
-      "properties": {
-        "uic": 8502020,
-        "didokId": "02020",
-        "operator": "SBB",
-        "displayName": "Rothenburg Station",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Hasenmoosstrasse 9",
-          "city": "Rothenburg (Station)",
-          "postalCode": "6023"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "210"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 17
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten entfallen diverse P+Rail-Parkplätze bis August 2025. Die Parkuhr ist in Pension. \nIhre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.\nDue to construction work, various P+Rail car parks will be closed until Ausgust 2025.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.\nA causa dei lavori di costruzione, diversi parcheggi P+Rail saranno chiusi fino ad agosto 2025.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.\nEn raison de travaux, plusieurs parkings P+Rail seront supprimés jusqu'en août 2025."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "73121036-e7f8-4164-9471-20dedda271c3",
       "geometry": {
         "type": "Point",
@@ -21868,93 +24346,6 @@
     },
     {
       "type": "Feature",
-      "id": "e0ee041d-bf36-429a-91c7-c686dbc6d6c6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.853791330831234,
-          47.395072351158404
-        ]
-      },
-      "properties": {
-        "uic": 8506009,
-        "didokId": "06009",
-        "operator": "SBB",
-        "displayName": "Saland",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Tösstalstrasse 133",
-          "city": "Saland (Bauma)",
-          "postalCode": "8493"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "379"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "25a72d70-5051-49d6-8ccb-f14a1253ca38",
       "geometry": {
         "type": "Point",
@@ -22042,175 +24433,6 @@
     },
     {
       "type": "Feature",
-      "id": "ad68b13d-3969-45c4-94b2-ea32bd4e8885",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.167245213529462,
-          47.45150459453097
-        ]
-      },
-      "properties": {
-        "uic": 8502116,
-        "didokId": "02116",
-        "operator": "SBB",
-        "displayName": "Schinznach Bad",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 33",
-          "city": "Schinznach Bad",
-          "postalCode": "5116"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "445"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 6
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "1a354adc-047b-4e25-b3b5-5ae5f0f0d982",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.903226688910442,
-          47.18265940889545
-        ]
-      },
-      "properties": {
-        "uic": 8503221,
-        "didokId": "03221",
-        "operator": "SBB",
-        "displayName": "Siebnen-Wangen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 3",
-          "city": "Siebnen-Wangen",
-          "postalCode": "8854"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "168"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 165
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "d76630e0-218c-40f1-9ac1-b1d0e7524a4b",
       "geometry": {
         "type": "Point",
@@ -22287,88 +24509,6 @@
           "it": "A causa di un cantiere, 3 parcheggi non saranno accessibili fino alla 30.09.2024.",
           "fr": "En raison d'un chantier, 3 places de parking sont inaccessibles jusqu'à 30.09.2024."
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "87d53212-6500-40d6-9b10-5f8f5c39dfab",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.854361185835996,
-          47.65656878182456
-        ]
-      },
-      "properties": {
-        "uic": 8506139,
-        "didokId": "06139",
-        "operator": "SBB",
-        "displayName": "Stein am Rhein",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 13",
-          "city": "Stein am Rhein",
-          "postalCode": "8260"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "8"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 53
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -23045,88 +25185,6 @@
           {
             "categoryType": "STANDARD",
             "total": 37
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "c4774821-af44-47ce-a989-39ce3fed53fc",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.806946162611519,
-          46.13511979178838
-        ]
-      },
-      "properties": {
-        "uic": 8505407,
-        "didokId": "05407",
-        "operator": "SBB",
-        "displayName": "San Nazzaro (Gambarogno)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Via Cantonale 60",
-          "city": "San Nazzaro (Gambarogno)",
-          "postalCode": "6575"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "102"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 5
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -23981,88 +26039,6 @@
           {
             "categoryType": "STANDARD",
             "total": 88
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "73c231d0-3865-4a80-b656-672e76dc57a3",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.387038376356803,
-          47.0417500558629
-        ]
-      },
-      "properties": {
-        "uic": 8504412,
-        "didokId": "04412",
-        "operator": "SBB",
-        "displayName": "Schüpfen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bernstrasse 16",
-          "city": "Schüpfen",
-          "postalCode": "3054"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "48"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 54
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -27033,93 +29009,6 @@
     },
     {
       "type": "Feature",
-      "id": "d159975c-c844-4c5d-9895-814dbc161cee",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.790642159795823,
-          47.550883183879186
-        ]
-      },
-      "properties": {
-        "uic": 8500301,
-        "didokId": "00301",
-        "operator": "SBB",
-        "displayName": "Rheinfelden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Imbissstand Bahnhofareal 2",
-          "city": "Rheinfelden",
-          "postalCode": "4310"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "394"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 47
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 4
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.   ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more.   ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.   ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.   "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1549d0ba-a6e9-4371-8e36-ebde551c3fd5",
       "geometry": {
         "type": "Point",
@@ -27191,93 +29080,6 @@
           }
         ],
         "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "576aeffa-b19e-4939-93d0-a7367e48a842",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.687154627644174,
-          47.67939584553593
-        ]
-      },
-      "properties": {
-        "uic": 8503427,
-        "didokId": "03427",
-        "operator": "SBB",
-        "displayName": "Schlatt",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Diessenhoferstrasse 1",
-          "city": "Schlatt",
-          "postalCode": "8252"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "412"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -29335,93 +31137,6 @@
     },
     {
       "type": "Feature",
-      "id": "64813559-897a-490f-8f4c-c18857f6bf05",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.551497764907664,
-          47.048320659113976
-        ]
-      },
-      "properties": {
-        "uic": 8505004,
-        "didokId": "05004",
-        "operator": "SBB",
-        "displayName": "Arth-Goldau",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 6",
-          "city": "Arth-Goldau",
-          "postalCode": "6410"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "64"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 90
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die 90 Parkplätze befinden sich an der Güterstrasse (Adresse Navigationsgeräte: Güterstrasse 6, 6410 Goldau).\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The 90 parking spaces are located on Güterstrasse (sat nav address: Güterstrasse 6, 6410 Goldau, Switzerland).\r\nThe parking meter is retired. But the P+Rail app can do much more.",
-          "it": "I 90 parcheggi si trovano in Güterstrasse (indirizzo per navigatore: Güterstrasse 6, 6410 Goldau).\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Les 90 places de stationnement se trouvent sur la Güterstrasse (adresse à indiquer dans les systèmes de navigation: Güterstrasse 6, 6410 Goldau).\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "f2ba567f-37ad-4fbf-90dd-eaf3bc30ddbd",
       "geometry": {
         "type": "Point",
@@ -30108,93 +31823,6 @@
     },
     {
       "type": "Feature",
-      "id": "e7525972-ca91-48ba-8b6c-2ebf1ecca848",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.77100620873358,
-          47.666321822100244
-        ]
-      },
-      "properties": {
-        "uic": 8503429,
-        "didokId": "03429",
-        "operator": "SBB",
-        "displayName": "Schlattingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 6",
-          "city": "Basadingen-Schlattingen",
-          "postalCode": "8255"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "414"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 5
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "ba3268fb-2ef4-4dd3-a2c0-cdf8254d4062",
       "geometry": {
         "type": "Point",
@@ -30855,88 +32483,6 @@
           {
             "categoryType": "STANDARD",
             "total": 21
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "c4e06053-d433-4595-bec4-b9a449823588",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.446894992871414,
-          47.48982957313251
-        ]
-      },
-      "properties": {
-        "uic": 8503316,
-        "didokId": "03316",
-        "operator": "SBB",
-        "displayName": "Steinmaur",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Steinmaur",
-          "postalCode": "8162"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "227"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 39
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -38482,93 +40028,6 @@
     },
     {
       "type": "Feature",
-      "id": "0b4b76e9-9d98-4cba-870e-483bf31b1ba7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.571312240854168,
-          47.32386165741721
-        ]
-      },
-      "properties": {
-        "uic": 8509400,
-        "didokId": "09400",
-        "operator": "SBB",
-        "displayName": "Oberriet",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 6",
-          "city": "Oberriet",
-          "postalCode": "9463"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "76"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 6
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "e6691123-d701-4ba4-a970-a4de03f3be5b",
       "geometry": {
         "type": "Point",
@@ -39254,88 +40713,6 @@
     },
     {
       "type": "Feature",
-      "id": "8d4c0d6e-e075-4e59-bbd9-3a0bf323fc8c",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.532246779006671,
-          47.45413902106405
-        ]
-      },
-      "properties": {
-        "uic": 8503311,
-        "didokId": "03311",
-        "operator": "SBB",
-        "displayName": "Rümlang",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 10",
-          "city": "Rümlang",
-          "postalCode": "8153"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "223"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 77
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a3e5318a-15de-45b0-b9a8-f6e7de9ea304",
       "geometry": {
         "type": "Point",
@@ -39412,175 +40789,6 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "7b25f83d-33a2-49ad-b20b-445e2074f3fd",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.197552785330762,
-          47.11598756796258
-        ]
-      },
-      "properties": {
-        "uic": 8502009,
-        "didokId": "02009",
-        "operator": "SBB",
-        "displayName": "Sempach-Neuenkirch",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 23",
-          "city": "Sempach-Neuenkirch",
-          "postalCode": "6203"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "207"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 49
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "d09293c1-5cdf-415a-9a5b-bdc72d6e06e1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.591587468333644,
-          47.465977520560884
-        ]
-      },
-      "properties": {
-        "uic": 8506313,
-        "didokId": "06313",
-        "operator": "SBB",
-        "displayName": "Rheineck",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 10",
-          "city": "Rheineck",
-          "postalCode": "9424"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "36"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 107
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -39918,180 +41126,6 @@
           }
         ],
         "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "0bd599da-516e-4320-b0dc-8b65b015ee3e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.144023268543906,
-          47.03784821604149
-        ]
-      },
-      "properties": {
-        "uic": 8508217,
-        "didokId": "08217",
-        "operator": "SBB",
-        "displayName": "Schachen LU",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 7",
-          "city": "Schachen LU (Werthenstein)",
-          "postalCode": "6105"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "356"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "810a1380-522e-48f5-a150-f9c2faa39f9b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.78964569361515,
-          47.53551146007607
-        ]
-      },
-      "properties": {
-        "uic": 8506018,
-        "didokId": "06018",
-        "operator": "SBB",
-        "displayName": "Rickenbach-Attikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Stationsstrasse 2",
-          "city": "Rickenbach-Attikon",
-          "postalCode": "8545"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "122"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 61
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -40702,93 +41736,6 @@
     },
     {
       "type": "Feature",
-      "id": "21527d51-0b18-44c4-8ebf-54109ed2ab6c",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.502453041982415,
-          47.477737682083976
-        ]
-      },
-      "properties": {
-        "uic": 8506311,
-        "didokId": "06311",
-        "operator": "SBB",
-        "displayName": "Rorschach",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Churerstrasse 23",
-          "city": "Rorschach",
-          "postalCode": "9400"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "35"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 55
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1b5bd747-b55c-453a-9724-2e9a9e10579b",
       "geometry": {
         "type": "Point",
@@ -41296,180 +42243,6 @@
     },
     {
       "type": "Feature",
-      "id": "b283db05-876b-463a-9261-f6a1ba8c5485",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.002042086880742,
-          47.462465394256846
-        ]
-      },
-      "properties": {
-        "uic": 8506010,
-        "didokId": "06010",
-        "operator": "SBB",
-        "displayName": "Sirnach",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Wilerstrasse 14",
-          "city": "Sirnach",
-          "postalCode": "8370"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "116"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 31
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "6e3beb6b-cb02-4143-80cd-5b763fdbf383",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.130545294604948,
-          47.65986821825864
-        ]
-      },
-      "properties": {
-        "uic": 8506132,
-        "didokId": "06132",
-        "operator": "SBB",
-        "displayName": "Tägerwilen-Gottlieben",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnstrasse 1",
-          "city": "Tägerwilen-Gottlieben",
-          "postalCode": "8274"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "349"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 4
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3d76eedc-e1ca-4c99-a393-70456c0c2122",
       "geometry": {
         "type": "Point",
@@ -41613,88 +42386,6 @@
           {
             "categoryType": "STANDARD",
             "total": 27
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ea4af3b4-0a44-40ae-bde7-33c95c042e32",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.984826476284248,
-          47.32171647922929
-        ]
-      },
-      "properties": {
-        "uic": 8502100,
-        "didokId": "02100",
-        "operator": "SBB",
-        "displayName": "Safenwil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 1",
-          "city": "Safenwil",
-          "postalCode": "5745"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "434"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 15
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -42233,93 +42924,6 @@
     },
     {
       "type": "Feature",
-      "id": "5d1fa595-78db-44f7-863a-0834a98c18a5",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.33903945217074,
-          47.0580445203619
-        ]
-      },
-      "properties": {
-        "uic": 8504413,
-        "didokId": "04413",
-        "operator": "SBB",
-        "displayName": "Suberg-Grossaffoltern",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bernstrasse 67",
-          "city": "Suberg-Grossaffoltern",
-          "postalCode": "3262"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "49"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 72
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "e53829ee-8ae3-4518-b90b-959b36ac0863",
       "geometry": {
         "type": "Point",
@@ -42754,180 +43358,6 @@
     },
     {
       "type": "Feature",
-      "id": "b2df3aea-89b7-4c6d-964a-6324afc62b28",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.062773662104932,
-          46.78278664317938
-        ]
-      },
-      "properties": {
-        "uic": 8504028,
-        "didokId": "04028",
-        "operator": "SBB",
-        "displayName": "Rosé",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Route de Rosé 49",
-          "city": "Rosé (Avry)",
-          "postalCode": "1754"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 300,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "268"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 15
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "78475af2-efec-4cca-af30-c23082e74a7b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.379630214923104,
-          47.5670023260876
-        ]
-      },
-      "properties": {
-        "uic": 8506121,
-        "didokId": "06121",
-        "operator": "SBB",
-        "displayName": "Romanshorn",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bankstrasse 6",
-          "city": "Romanshorn",
-          "postalCode": "8590"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "2"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 99
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "7e8ff0ab-9a87-40bc-a6e7-e5080f08b218",
       "geometry": {
         "type": "Point",
@@ -43168,93 +43598,6 @@
           }
         ],
         "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "7e56dd5c-320b-4fa7-9a5d-efbc33c82bec",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.074281855768314,
-          47.18012405162308
-        ]
-      },
-      "properties": {
-        "uic": 8502010,
-        "didokId": "02010",
-        "operator": "SBB",
-        "displayName": "St. Erhard-Knutwil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhöfli 5",
-          "city": "St. Erhard-Knutwil",
-          "postalCode": "6212"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "431"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -44463,88 +44806,6 @@
     },
     {
       "type": "Feature",
-      "id": "a3dd5a87-d88c-45f8-8017-ff42a5edbd9f",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.397646976494833,
-          47.18781593539478
-        ]
-      },
-      "properties": {
-        "uic": 8502218,
-        "didokId": "02218",
-        "operator": "SBB",
-        "displayName": "Sins",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 30",
-          "city": "Sins",
-          "postalCode": "5643"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "450"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 22
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "2de404cb-b82c-4a51-961a-e7b92681f1f1",
       "geometry": {
         "type": "Point",
@@ -45134,93 +45395,6 @@
     },
     {
       "type": "Feature",
-      "id": "42ff768c-321a-40c0-8b9b-8ea04ee366d6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.047648173769746,
-          47.356029732345284
-        ]
-      },
-      "properties": {
-        "uic": 8502102,
-        "didokId": "02102",
-        "operator": "SBB",
-        "displayName": "Oberentfelden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 1",
-          "city": "Oberentfelden",
-          "postalCode": "5036"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "247"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 25
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a8db3cf0-2bf2-4c26-b014-c907d3de4afe",
       "geometry": {
         "type": "Point",
@@ -45554,93 +45728,6 @@
     },
     {
       "type": "Feature",
-      "id": "49b16773-ddf5-4a2d-a82a-93f20910af1e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.724986402973297,
-          46.91929030522081
-        ]
-      },
-      "properties": {
-        "uic": 8508205,
-        "didokId": "08205",
-        "operator": "SBB",
-        "displayName": "Signau",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 3",
-          "city": "Signau",
-          "postalCode": "3534"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "354"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 6
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "cd0b44a2-d2e4-4318-8ff1-eafb2fde15af",
       "geometry": {
         "type": "Point",
@@ -45799,93 +45886,6 @@
           }
         ],
         "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "e864361f-9082-47e2-b016-60402a11776f",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.255304652467356,
-          46.86245519884059
-        ]
-      },
-      "properties": {
-        "uic": 8504102,
-        "didokId": "04102",
-        "operator": "SBB",
-        "displayName": "Schmitten",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Mülitalstrasse 3",
-          "city": "Schmitten",
-          "postalCode": "3185"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "298"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 99
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [

--- a/tests/converters/data/opendata_swiss.json
+++ b/tests/converters/data/opendata_swiss.json
@@ -3,12 +3,532 @@
   "features": [
     {
       "type": "Feature",
+      "id": "bdbf1675-67b8-41f7-8d5c-4fdda127d0d9",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.08054668268791,
+          47.37057701332991
+        ]
+      },
+      "properties": {
+        "uic": 8502103,
+        "didokId": "02103",
+        "operator": "SBB",
+        "displayName": "Suhr",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 3",
+          "city": "Suhr",
+          "postalCode": "5034"
+        },
+        "pricingModel": {
+          "minimumDuration": 15,
+          "maximumDuration": 1440,
+          "maximumDayPrice": null,
+          "viableIncrement": 15,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 0
+            },
+            {
+              "startingFrom": 15,
+              "price": 25
+            },
+            {
+              "startingFrom": 300,
+              "price": 0
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": null
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 5
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "7acae6bc-b851-4d6a-9570-caf85bfb0951",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.5595785135814415,
+          46.93399619164299
+        ]
+      },
+      "properties": {
+        "uic": 8589198,
+        "didokId": "89198",
+        "operator": "RBS",
+        "displayName": "Worbboden (RBS)",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhof Worbboden",
+          "city": "Worbboden",
+          "postalCode": "3076"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "974"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 20
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d339ce85-1731-4d9f-bd35-b663a95976ae",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.795317621390852,
+          47.445740227553564
+        ]
+      },
+      "properties": {
+        "uic": 8506005,
+        "didokId": "06005",
+        "operator": "SBB",
+        "displayName": "Rikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Tösstalstrasse 49",
+          "city": "Rikon (Zell)",
+          "postalCode": "8486"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "377"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 11
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "8e8cf5f3-6598-44cf-b970-ce6879d762ce",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.168089258885999,
+          47.391560608404255
+        ]
+      },
+      "properties": {
+        "uic": 8502119,
+        "didokId": "02119",
+        "operator": "SBB",
+        "displayName": "Lenzburg",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 50",
+          "city": "Lenzburg",
+          "postalCode": "5600"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "252"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 264
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 5
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten eingeschränktes Platzangebot. \nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.  ",
+          "en": "Limited space available due to construction work.\nThe parking meter is retired. But the P+Rail app can do much more.  ",
+          "it": "Spazio limitato disponibile a causa di lavori di costruzione.\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.  \n ",
+          "fr": "En raison de travaux, l'espace disponible est limité.\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "a1e6df62-2673-4773-9e3e-cdaca572572d",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.25675271308838,
+          47.57412394658236
+        ]
+      },
+      "properties": {
+        "uic": 8503501,
+        "didokId": "03501",
+        "operator": "SBB",
+        "displayName": "Döttingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 2",
+          "city": "Döttingen",
+          "postalCode": "5312"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "277"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 128
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Ab Juli 2025 stehen die Parkplätze 70 - 96 (Parzelle Bürli-Areal) nicht mehr zur Verfügung. \nAn der Parkuhr kann nur mit Kreditkarte bezahlt werden. Keine Bezahlung mit Bargeld möglich.",
+          "en": "From July 2025, car parking spots 70 - 96 will no longer be available. \nPayment at the car parking counter is only possible by credit card.",
+          "it": "Da luglio 2025, i parcheggi 70-96 non saranno più disponibili. \nIl pagamento al parchimetro è possibile solo con carta di credito.",
+          "fr": "A partir de juillet 2025, les places de stationnement 70 - 96 ne seront plus disponibles.\nLe paiement au parcmètre n'est possible que par carte de crédit."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "45b3ae1c-91f5-4a75-a856-2289bed7f9c7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.653605211773002,
+          47.634899905289174
+        ]
+      },
+      "properties": {
+        "uic": 8506048,
+        "didokId": "06048",
+        "operator": "SBB",
+        "displayName": "Marthalen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Ruedelfingerstrass 1",
+          "city": "Marthalen",
+          "postalCode": "8460"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 150
+            }
+          ],
+          "monthlyTicketPrice": null,
+          "yearlyTicketPrice": null,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "133"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 117
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "8838b5c9-1370-4627-9b7e-55fc072640f2",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.854945,
-          47.260032
+          8.8547316760077,
+          47.25997306074745
         ]
       },
       "properties": {
@@ -97,8 +617,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.358766,
-          46.226804
+          7.358414791980459,
+          46.226776705756485
         ]
       },
       "properties": {
@@ -179,8 +699,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.342447,
-          46.224195
+          7.341746684028533,
+          46.22414169487936
         ]
       },
       "properties": {
@@ -348,8 +868,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.270579,
-          46.208551
+          7.2709056402255134,
+          46.20868801499592
         ]
       },
       "properties": {
@@ -403,89 +923,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
             "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "7afbfae8-65fc-42b3-b0ca-2115794f3b4f",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.793171861902,
-          47.317644953648
-        ]
-      },
-      "properties": {
-        "uic": 8503123,
-        "didokId": "03123",
-        "operator": "SBB",
-        "displayName": "Wetzikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rapperswilerstrasse 9",
-          "city": "Wetzikon",
-          "postalCode": "8620"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": null,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 0
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": null
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 116
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -672,12 +1110,8477 @@
     },
     {
       "type": "Feature",
+      "id": "4dc820be-05b6-4e57-af8b-bd419e66a10a",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.000430272502468,
+          46.74890788092593
+        ]
+      },
+      "properties": {
+        "uic": 8504025,
+        "didokId": "04025",
+        "operator": "SBB",
+        "displayName": "Chénens",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Place de la Gare 2",
+          "city": "Chénens",
+          "postalCode": "1744"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "1155"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 15
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "81b5f0c9-0f32-40e4-8ad9-154fe4d1c1cd",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.726123369700376,
+          46.488626720994176
+        ]
+      },
+      "properties": {
+        "uic": 8501124,
+        "didokId": "01124",
+        "operator": "SBB",
+        "displayName": "Cully",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Place de la Gare 6",
+          "city": "Cully",
+          "postalCode": "1096"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "1167"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 64
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Vom 13.03.2025 au 31.03.2025 sind die drei Parkplätze 34, 35 und 36 aufgrund Bauarbeiten nicht verfügbar.",
+          "en": "From 13.03.2025 to 31.03.2025, the three car parks 34, 35 and 36 will not be available due to construction work.",
+          "it": "Dal 13.03.2025 al 31.03.2025, i tre parcheggi 34, 35 e 36 non saranno disponibili a causa di lavori di costruzione.",
+          "fr": "Du 13.03.2025 au 31.03.2025, les trois parkings 34, 35 et 36 ne seront pas disponibles en raison de travaux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "45cacd68-59cd-49a3-a7b6-dc3060bb9551",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.542543,
+          47.20333
+        ]
+      },
+      "properties": {
+        "uic": null,
+        "didokId": null,
+        "operator": "RBS",
+        "displayName": "Solothurn (RBS, Zuchwilerstrasse)",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Zuchwilerstrasse",
+          "city": "Solothurn",
+          "postalCode": "4500"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": null
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 30
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "PP 60-89",
+          "en": "PP 60-89",
+          "it": "PP 60-89",
+          "fr": "PP 60-89"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "41972fee-3337-4bcb-a264-de759dbbfdec",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.589794118217212,
+          46.66867036408903
+        ]
+      },
+      "properties": {
+        "uic": 8505119,
+        "didokId": "05119",
+        "operator": "SBB",
+        "displayName": "Göschenen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Gotthardstrasse 16",
+          "city": "Göschenen",
+          "postalCode": "6487"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 3000,
+          "yearlyTicketPrice": 30000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "07:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "69"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 25
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "5cc50502-6c26-4055-9bf0-358fd3a07913",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.689269922914583,
+          46.510772765487864
+        ]
+      },
+      "properties": {
+        "uic": 8505202,
+        "didokId": "05202",
+        "operator": "SBB",
+        "displayName": "Ambrì-Piotta",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Ambri Road 43",
+          "city": "Ambrì-Piotta (Quinto)",
+          "postalCode": "6775"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "71"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "f22843bd-36a7-481b-b657-d55946c64e3d",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.274858766650588,
+          47.42809080475145
+        ]
+      },
+      "properties": {
+        "uic": 8516219,
+        "didokId": "16219",
+        "operator": "SBB",
+        "displayName": "Mellingen-Heitersberg",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 80",
+          "city": "Mellingen-Heitersberg",
+          "postalCode": "5507"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "53"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 165
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 2
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": {
+          "eChargingStationOperatorID": "30bd1b8b-b1a6-4957-9d02-eb607c1f9ec2",
+          "eChargingStationOperatorName": "swisscharge",
+          "eChargingStationOperatorLink": "https://map.swisscharge.ch/"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1fb345a3-8605-49b8-931a-58da17e792c9",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.287855819706088,
+          47.16793134871768
+        ]
+      },
+      "properties": {
+        "uic": 8502024,
+        "didokId": "02024",
+        "operator": "SBB",
+        "displayName": "Hochdorf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 2",
+          "city": "Hochdorf",
+          "postalCode": "6280"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "213"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 28
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "fb7a54c1-c5ff-49a2-8bcb-f1008c3088bf",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.967954954681215,
+          47.2423295719763
+        ]
+      },
+      "properties": {
+        "uic": 8502003,
+        "didokId": "02003",
+        "operator": "SBB",
+        "displayName": "Reiden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Werkstrasse 5",
+          "city": "Reiden",
+          "postalCode": "6260"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "203"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 65
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "82881566-f59e-415f-9042-321a01eea205",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.740143552813281,
+          47.53483863947263
+        ]
+      },
+      "properties": {
+        "uic": 8506020,
+        "didokId": "06020",
+        "operator": "SBB",
+        "displayName": "Seuzach",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Stationsstrasse 58",
+          "city": "Seuzach",
+          "postalCode": "8472"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "382"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 73
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e37346bf-0cca-408f-a40c-080a393a5a57",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.096003303598181,
+          47.06329396701857
+        ]
+      },
+      "properties": {
+        "uic": 8504226,
+        "didokId": "04226",
+        "operator": "SBB",
+        "displayName": "La Neuveville",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Place de la Gare 2",
+          "city": "La Neuveville",
+          "postalCode": "2520"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            },
+            {
+              "startingFrom": 120,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "190"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 12
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1b4cff0c-57d4-4a0e-bafb-a7a246f530c4",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.277716629420891,
+          47.04342978296451
+        ]
+      },
+      "properties": {
+        "uic": 8504404,
+        "didokId": "04404",
+        "operator": "SBB",
+        "displayName": "Aarberg",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 6",
+          "city": "Aarberg",
+          "postalCode": "3270"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "45"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 25
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1c29f640-b703-43bd-95e8-36ae28263ef1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.503847747964805,
+          47.010399311652726
+        ]
+      },
+      "properties": {
+        "uic": 8509004,
+        "didokId": "09004",
+        "operator": "SBB",
+        "displayName": "Bad Ragaz",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Unterrainstrasse 1",
+          "city": "Bad Ragaz",
+          "postalCode": "7310"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "62"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 60
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "13680e0a-45a5-4f2d-ba1a-abd41b9b85b0",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.029845855903497,
+          47.151973052235434
+        ]
+      },
+      "properties": {
+        "uic": 8503224,
+        "didokId": "03224",
+        "operator": "SBB",
+        "displayName": "Bilten",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Speerstrasse 1",
+          "city": "Bilten",
+          "postalCode": "8865"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "06:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "171"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 21
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "8ff47646-0791-455f-9a7a-e8d35dd91803",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.281062248209814,
+          47.07184402315231
+        ]
+      },
+      "properties": {
+        "uic": 8502021,
+        "didokId": "02021",
+        "operator": "SBB",
+        "displayName": "Emmenbrücke",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Schützenmattstrasse 36",
+          "city": "Emmenbrücke",
+          "postalCode": "6020"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "211"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 89
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "561f74e0-7410-42dd-a5bb-437e49a92905",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.747064783134916,
+          46.947265574068325
+        ]
+      },
+      "properties": {
+        "uic": 8508206,
+        "didokId": "08206",
+        "operator": "SBB",
+        "displayName": "Emmenmatt",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 135",
+          "city": "Emmenmatt",
+          "postalCode": "3543"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "24"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "a459aa1d-11c1-444d-b870-8b097d90372b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.080934163022468,
+          47.009802785822394
+        ]
+      },
+      "properties": {
+        "uic": 8503232,
+        "didokId": "03232",
+        "operator": "SBB",
+        "displayName": "Mitlödi",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 4",
+          "city": "Glarus-Süd / Mitlödi",
+          "postalCode": "8756"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "566"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 10
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e13d2788-80fa-4b81-addc-9a8ff3202503",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.950675815025103,
+          47.541215544989335
+        ]
+      },
+      "properties": {
+        "uic": 8500320,
+        "didokId": "00320",
+        "operator": "SBB",
+        "displayName": "Stein-Säckingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Altes Bahnhofgebäude",
+          "city": "Stein AG",
+          "postalCode": "4332"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 150
+            }
+          ],
+          "monthlyTicketPrice": 9000,
+          "yearlyTicketPrice": 90000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "155"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 244
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 4
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "4 E-Ladestation von Alfen vorhanden.  ",
+          "en": "4 e-charging stations from Alfen available.  ",
+          "it": "4 stazioni di ricarica elettronica disponibili presso Alfen.  \r\n ",
+          "fr": "4 stations de recharge électrique d'Alfen disponibles.  "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": {
+          "eChargingStationOperatorID": "de5d5816-ac74-4dfd-9a41-aa81421b0a87",
+          "eChargingStationOperatorName": "SBB",
+          "eChargingStationOperatorLink": "https://www.sbb.ch/"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "05804c7d-8b40-442f-b739-57f769e5ccfc",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.936301061581621,
+          46.91470491780262
+        ]
+      },
+      "properties": {
+        "uic": 8508210,
+        "didokId": "08210",
+        "operator": "SBB",
+        "displayName": "Escholzmatt",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 2",
+          "city": "Escholzmatt",
+          "postalCode": "6182"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "27"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 56
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "986fb329-0bb2-4738-9854-914b3ddc1c99",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.907132924518558,
+          47.32081214112504
+        ]
+      },
+      "properties": {
+        "uic": 8502000,
+        "didokId": "02000",
+        "operator": "SBB",
+        "displayName": "Aarburg-Oftringen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 2",
+          "city": "Aarburg-Oftringen",
+          "postalCode": "4663"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "202"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 25
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "052c9b04-64ff-4ccf-8a1a-fde1bd0d5532",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.201869122547407,
+          47.26803325445042
+        ]
+      },
+      "properties": {
+        "uic": 8502034,
+        "didokId": "02034",
+        "operator": "SBB",
+        "displayName": "Beinwil am See",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Hombergstrasse 4",
+          "city": "Beinwil am See",
+          "postalCode": "5712"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "217"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 68
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c23edf7e-a81e-4be8-bcb1-0a02e67a5fb7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.46904104120216,
+          47.327724508514144
+        ]
+      },
+      "properties": {
+        "uic": 8502222,
+        "didokId": "02222",
+        "operator": "SBB",
+        "displayName": "Bonstetten-Wettswil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Stationsstrasse 4",
+          "city": "Bonstetten-Wettswil",
+          "postalCode": "8906"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "07:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "323"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 107
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "An Sonn- und Feiertagen kostenlos.",
+          "en": "Free of charge on Sundays and public holidays.",
+          "it": "Gratuito la domenica e nei giorni festivi.",
+          "fr": "Gratuit les dimanches et jours fériés."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "def41dab-a462-45f4-a3dd-ee5985fc0a55",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.273360880500158,
+          47.09110189305415
+        ]
+      },
+      "properties": {
+        "uic": 8502012,
+        "didokId": "02012",
+        "operator": "SBB",
+        "displayName": "Emmenbrücke Kapf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bachtalenstrasse 4",
+          "city": "Rothenburg Dorf (Kapf)",
+          "postalCode": "6020"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "208"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 5
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Keine Parkplätze vorhanden.",
+          "en": "No parking available",
+          "it": "Nessun parcheggio disponibile",
+          "fr": "Pas de places de parc disponibles."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1b42fd3a-f242-4083-946c-ae9fff13c24a",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.225921758454417,
+          47.55126161375416
+        ]
+      },
+      "properties": {
+        "uic": 8506107,
+        "didokId": "06107",
+        "operator": "SBB",
+        "displayName": "Erlen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 2",
+          "city": "Erlen",
+          "postalCode": "8586"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "387"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e7263572-b67e-4983-96df-2d660eb57a87",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.22367698605029,
+          47.244744369756155
+        ]
+      },
+      "properties": {
+        "uic": 8502029,
+        "didokId": "02029",
+        "operator": "SBB",
+        "displayName": "Mosen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Schwarzenbacherstrasse 2",
+          "city": "Mosen",
+          "postalCode": "6295"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "215"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 15
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "0e81a485-c526-45c4-82ba-7875896a5418",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.61901008600514,
+          47.060588802631656
+        ]
+      },
+      "properties": {
+        "uic": 8508005,
+        "didokId": "08005",
+        "operator": "SBB",
+        "displayName": "Burgdorf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bucherstrasse 2",
+          "city": "Burgdorf",
+          "postalCode": "3400"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1200,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "108"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 108
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Eingeschränktes Platzangebot",
+          "en": "Limited space available",
+          "it": "Spazio limitato disponibile",
+          "fr": "Espace réduit"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "3b77f3b0-b1df-4fd2-9788-01f8627c6120",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.766541600338412,
+          47.33577014498019
+        ]
+      },
+      "properties": {
+        "uic": 8503124,
+        "didokId": "03124",
+        "operator": "SBB",
+        "displayName": "Aathal-Seegräben",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Gstalderstrasse 4",
+          "city": "Aathal-Seegräben",
+          "postalCode": "8607"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "340"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 32
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c74fda76-3d10-4823-8656-a3aeee96fde6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.365112902257247,
+          47.24726724796692
+        ]
+      },
+      "properties": {
+        "uic": 8502216,
+        "didokId": "02216",
+        "operator": "SBB",
+        "displayName": "Benzenschwil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 2",
+          "city": "Benzenschwil",
+          "postalCode": "5636"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "320"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 15
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "61813d7c-eb57-4a4c-a266-5a35872237f6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.698652839131151,
+          46.90016293114056
+        ]
+      },
+      "properties": {
+        "uic": 8508204,
+        "didokId": "08204",
+        "operator": "SBB",
+        "displayName": "Bowil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Bowil",
+          "postalCode": "3533"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "23"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 24
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "70cca348-bcec-4ff6-b50c-4a7793e0970e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.8757745135082,
+          47.6456248470124
+        ]
+      },
+      "properties": {
+        "uic": 8506138,
+        "didokId": "06138",
+        "operator": "SBB",
+        "displayName": "Eschenz",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Eschenz",
+          "postalCode": "8264"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 3000,
+          "yearlyTicketPrice": 30000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "350"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 7
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "192fafcd-2390-4b91-9e02-80b0286d33ac",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.388157408379422,
+          47.225216591372096
+        ]
+      },
+      "properties": {
+        "uic": 8502217,
+        "didokId": "02217",
+        "operator": "SBB",
+        "displayName": "Mühlau",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Mühlau",
+          "postalCode": "5642"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "449"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "80b76b2c-d28a-4721-88e2-4b7cde553489",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.9633474628670955,
+          46.31535439511113
+        ]
+      },
+      "properties": {
+        "uic": 8501400,
+        "didokId": "01400",
+        "operator": "SBB",
+        "displayName": "Aigle",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Chemin Novassalles 4",
+          "city": "Aigle",
+          "postalCode": "1860"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "314"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 347
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Verwaltung der Parkplätze der SBB und der Gemeinde\nGemeindeanlage für 30% der Parkplätze nur bis 22 Uhr zugänglich, für die anderen 70% durchgängig offen. Stundentarif: CHF 1.-/Stunde, min. 2 Stunden.  ",
+          "en": "Management of SBB and municipal parking spaces. Municipal access limited to 22 hours for 30% of the parking spaces; 24-hour access for the restHourly rate: CHF 1 per hour, min. 2 hours.  ",
+          "it": "Gestione dei posti FFS e comunali\nAccesso comunale fino alle ore 22 per il 30% dei posti, il restante 70% è accessibile 24h/24Tariffa oraria: CHF 1.-/ora, min. 2 ore.  ",
+          "fr": "Gestion des places CFF et communales\nAccès communal limité à 22h pour 30% des places, pour les autres 70% 24h/24Tarif horaire: CHF 1.-/heure, min. 2 heures.  "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ffdf67bf-9257-4537-a32c-a6543df5dbfd",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.518813925982951,
+          46.69793275750233
+        ]
+      },
+      "properties": {
+        "uic": 8501107,
+        "didokId": "01107",
+        "operator": "SBB",
+        "displayName": "Arnex-sur-Orbe",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Route de la Gare 11",
+          "city": "Arnex-sur-Orbe",
+          "postalCode": "1321"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "285"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 21
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Von 26. April 2024 bis Juli 2025 werden mehrere Parkplätze im P+Rail Arnex vorübergehend aufgehoben. \nDie gelegentlichen Benutzer des P+Rail von Arnex werden gebeten, die P+Rail-Parkplätze von La Sarraz und Croy zu benutzen. \nWährend dieser Zeit ist der P+Rail in Arnex ausschließlich für Inhaber eines P+Rail-Abonnements reserviert.",
+          "en": "A number of parking spaces will be temporarily withdrawn from the Arnex P+Rail from April 2024 to July 2025. \nOccasional users of the P+Rail d'Arnex are asked to use the P+Rail car parks at La Sarraz and Croy. \nDuring this period, the Arnex P+Rail is strictly reserved for P+Rail season ticket holders.",
+          "it": "Da aprile 2024 a luglio 2025 saranno temporaneamente ritirati alcuni posti auto dall'Arnex P+Rail. \nGli utenti occasionali del P+Rail d'Arnex sono invitati a utilizzare i parcheggi P+Rail di La Sarraz e Croy. \nDurante questo periodo, l'Arnex P+Rail è strettamente riservato ai titolari di un abbonamento P+Rail.",
+          "fr": "Plusieurs places de parc sont provisoirement supprimées dans le P+Rail d'Arnex de 26 avril 2024 à juillet 2025. \nLes utilisateurs occasionnels du P+Rail d'Arnex sont priés d'utili\u0002ser les parking P+Rail de La Sarraz et de Croy. \nDurant cette période, le P+Rail d'Arnex est strictement réservé aux porteurs d'abonnements P+Rail."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "24f6f812-9483-4293-9303-d1af7ed058fd",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.6110114441836,
+          47.00030207822353
+        ]
+      },
+      "properties": {
+        "uic": 8505007,
+        "didokId": "05007",
+        "operator": "SBB",
+        "displayName": "Brunnen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 46",
+          "city": "Brunnen",
+          "postalCode": "6440"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "66"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 43
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1f5a5d4a-f97d-4d9d-9391-5c43c503e379",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.958492004700332,
+          47.46155710695365
+        ]
+      },
+      "properties": {
+        "uic": 8506011,
+        "didokId": "06011",
+        "operator": "SBB",
+        "displayName": "Eschlikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Eschlikon",
+          "postalCode": "8360"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "117"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 80
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "2b713d4f-6f4a-4ef7-894a-30280881e4f6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.453725616886024,
+          47.02076511208678
+        ]
+      },
+      "properties": {
+        "uic": 8504411,
+        "didokId": "04411",
+        "operator": "SBB",
+        "displayName": "Münchenbuchsee",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Dammweg 1",
+          "city": "Münchenbuchsee",
+          "postalCode": "3053"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 200
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "47"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 87
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d5622d32-ed46-4a4e-b4a5-e197f2834b7b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.610442741658243,
+          46.5276692997967
+        ]
+      },
+      "properties": {
+        "uic": 8505201,
+        "didokId": "05201",
+        "operator": "SBB",
+        "displayName": "Airolo",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Via della Stazione 29",
+          "city": "Airolo",
+          "postalCode": "6780"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "70"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 36
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "91a9d7e8-b188-4138-89a1-c9fe2b00a00e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.302878420338903,
+          47.55027385219071
+        ]
+      },
+      "properties": {
+        "uic": 8506109,
+        "didokId": "06109",
+        "operator": "SBB",
+        "displayName": "Amriswil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Poststrasse 6",
+          "city": "Amriswil",
+          "postalCode": "8580"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "137"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 78
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Nordstrasse: 37 Parkplätze\r\nOst: 27 Parkplätze\r\nBahnhofplatz: 14 Parkplätze",
+          "en": "Nordstrasse: 37 parking spaces\r\nOst: 27 parking spaces\r\nBahnhofplatz: 14 parking spaces ",
+          "it": "Nordstrasse: 37 posti de parcheggio\r\nOst: 27 posti de parcheggio\r\nBahnhofplatz: 14 posti de parcheggio",
+          "fr": "Nordstrasse: 37 places\r\nOst: 27 places \r\nBahnhofplatz: 14 places"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "7e625c16-2be0-4e8e-aac7-4b04818f7f55",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.479756640919028,
+          47.16704973156033
+        ]
+      },
+      "properties": {
+        "uic": 8509404,
+        "didokId": "09404",
+        "operator": "SBB",
+        "displayName": "Buchs SG",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rheinstrasse 4",
+          "city": "Buchs SG",
+          "postalCode": "9470"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "78"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 108
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more. Day parking tickets can also be purchased from the ticket machine.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. I biglietti per il parcheggio giornaliero possono essere acquistati anche presso la biglietteria automatica.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. Les tickets de parking à la journée peuvent aussi être achetés aux distributeurs de billets."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d1e19871-8d37-4347-aa2a-a18a9c575efc",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.7517888921211,
+          47.384347990581745
+        ]
+      },
+      "properties": {
+        "uic": 8503302,
+        "didokId": "03302",
+        "operator": "SBB",
+        "displayName": "Fehraltorf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 37",
+          "city": "Fehraltorf",
+          "postalCode": "8320"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "219"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 78
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "0aca6999-d48d-4c64-af07-90e22fedf367",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.560166248753484,
+          46.871406650268064
+        ]
+      },
+      "properties": {
+        "uic": 8500552,
+        "didokId": "00552",
+        "operator": "SBB",
+        "displayName": "Münsingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Belpbergstrasse 15",
+          "city": "Münsingen",
+          "postalCode": "3110"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "57"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 74
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "913b36a4-137d-40f5-b15d-d33d9e39c1f6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.631051292308122,
+          46.87758766785428
+        ]
+      },
+      "properties": {
+        "uic": 8505113,
+        "didokId": "05113",
+        "operator": "SBB",
+        "displayName": "Altdorf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 1",
+          "city": "Altdorf",
+          "postalCode": "6460"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "67"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 62
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "bb78349c-446e-4d40-83ba-9d22756d321e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.43743445606603,
+          47.45289385783123
+        ]
+      },
+      "properties": {
+        "uic": 8503527,
+        "didokId": "03527",
+        "operator": "SBB",
+        "displayName": "Buchs-Dällikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Furtbachstrasse 4",
+          "city": "Buchs-Dällikon",
+          "postalCode": "8107"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "292"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 57
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "94d97311-3042-4362-84e9-2cf0fba9a7c1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.646614199885045,
+          47.69182955779352
+        ]
+      },
+      "properties": {
+        "uic": 8503425,
+        "didokId": "03425",
+        "operator": "SBB",
+        "displayName": "Feuerthalen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Diessenhoferstrasse 25",
+          "city": "Feuerthalen",
+          "postalCode": "8245"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "411"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 12
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "2797c219-6441-408b-b02d-c21dece4ce41",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.227137982097021,
+          47.63334626342776
+        ]
+      },
+      "properties": {
+        "uic": 8506126,
+        "didokId": "06126",
+        "operator": "SBB",
+        "displayName": "Münsterlingen-Scherzingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Seestrasse 30",
+          "city": "Münsterlingen",
+          "postalCode": "8596"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 3000,
+          "yearlyTicketPrice": 30000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "348"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 6
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c8c7f6ca-150c-4f55-9f6c-8b77dd4504a8",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.551658290818679,
+          46.547816926709125
+        ]
+      },
+      "properties": {
+        "uic": 8501117,
+        "didokId": "01117",
+        "operator": "SBB",
+        "displayName": "Bussigny",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rue de la Gare 5",
+          "city": "Bussigny",
+          "postalCode": "1030"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "290"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 70
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "4225c609-235d-47a1-af53-4b1fc47af458",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.013742169749186,
+          47.50797289847443
+        ]
+      },
+      "properties": {
+        "uic": 8500305,
+        "didokId": "00305",
+        "operator": "SBB",
+        "displayName": "Frick",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 1",
+          "city": "Frick",
+          "postalCode": "5070"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "395"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 139
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 5
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Mit einer Monats- oder Jahresparkkarte P+R Frick kann wie folgt parkiert werden: \r\n- Parkhaus Bahnhof (Tageskarte CHF 8.00, an der Parkkasse zu bezahlen)\r\n- SBB P+R-Anlage (Stunden- und Tageskarte auch in der P+Rail-App buchbar: \"Frick\"\r\n- Parkplatz Blaie (Blaienweg, gegenüber Tierarztpraxis, ca 5 Minuten Fussweg / Stunden- und Tageskarten auch in der P+Rail-App buchbar: \"Frick (P+Rail Blaieweg)\"  \r\n\r\n",
+          "en": "With a monthly or annual parking card P+R Frick can be parked as follows: \r\n- Parking at Railwaystation (day pass CHF 8.00, to be paid at the parking cash desk)  \r\n- SBB P+R facility  \r\n- Blaien car park (Blaienweg, opposite the veterinary practice, approx. 5 minutes walk / day tickets not valid!)  ",
+          "it": "Con una tessera di parcheggio mensile o annuale, nel P+R di Frick può essere parcheggiato come segue:\r\n- FFS Parcheggio alla stazione (biglietti giornalieri CHF 8.00, da pagare alla cassa del parcheggio) \r\n- Impianto P+R delle FFS \r\n- Parcheggio Blaien (Blaienweg, di fronte allo studio veterinario, ca. 5 minuti a piedi / biglietti giornalieri non validi!)  \r\n \r\n",
+          "fr": "Avec une carte de stationnement mensuelle ou annuelle, il est possible de se parquer comme suit auprès de P+R Frick: \r\n- Parking de la gare (billets journaliers CHF 8.00, à payer à la caisse du parking)\r\n- Le dispositif P+R du CFF  \r\n- Parking Blaie (Blaienweg, en face du cabinet vétérinaire, environ 5 à pied / billets journaliers non valables !)  \r\n"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "6e8cf993-c0db-4cd1-a13d-5b357afc94b7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.112896562874898,
+          46.92435571712321
+        ]
+      },
+      "properties": {
+        "uic": 8504128,
+        "didokId": "04128",
+        "operator": "SBB",
+        "displayName": "Murten",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Freiburgstrasse 14",
+          "city": "Murten",
+          "postalCode": "3280"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 200
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": 9000,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": 90000
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "306"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 74
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "bbefd5bf-5b53-4714-b89d-854f74aa3caf",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.318887849878276,
+          47.09930210891781
+        ]
+      },
+      "properties": {
+        "uic": 8504415,
+        "didokId": "04415",
+        "operator": "SBB",
+        "displayName": "Busswil bei Büren",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Busswil bei Büren",
+          "postalCode": "3292"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "51"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 30
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.             ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "6c1db299-8f0e-4301-8905-d46e77cd90a0",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.846863025527383,
+          47.46565701908935
+        ]
+      },
+      "properties": {
+        "uic": 8500027,
+        "didokId": "00027",
+        "operator": "SBB",
+        "displayName": "Gelterkinden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 12",
+          "city": "Gelterkinden",
+          "postalCode": "4460"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "232"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 88
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.  The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "386bdae2-5e73-41ad-9e6f-d4f7978197ea",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.90370329381452,
+          46.98415609535081
+        ]
+      },
+      "properties": {
+        "uic": 8504220,
+        "didokId": "04220",
+        "operator": "SBB",
+        "displayName": "Neuchâtel-Serrières",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rue des Amandiers 6",
+          "city": "Neuchâtel-Serrières",
+          "postalCode": "2000"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "186"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 22
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "4cf972cf-6ad2-46db-b071-ddba61e9e751",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.915275063034516,
+          47.3133851500949
+        ]
+      },
+      "properties": {
+        "uic": 8503137,
+        "didokId": "03137",
+        "operator": "SBB",
+        "displayName": "Gibswil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Tösstalstrasse 465",
+          "city": "Gibswil",
+          "postalCode": "8498"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "460"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 11
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "86accb98-fcf9-4c6f-b5f2-c54ec7b87e01",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.625031415431254,
+          47.682223253746166
+        ]
+      },
+      "properties": {
+        "uic": 8503423,
+        "didokId": "03423",
+        "operator": "SBB",
+        "displayName": "Neuhausen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 27",
+          "city": "Neuhausen",
+          "postalCode": "8212"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "410"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 66
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Eingeschränktes Parkplatzangebot ab dem 01.04. - 31.12.2024.\n",
+          "en": "Restricted parking from 01.04. - 31.12.2024.",
+          "it": "Parcheggio limitato dal 01.04. al 31.12.2024.",
+          "fr": "Offre de stationnement limitée à partir du 01.04. - 31.12.2024."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "29f733bf-8dab-41d1-8819-5295df317c0b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.50355673757135,
+          47.48828034920154
+        ]
+      },
+      "properties": {
+        "uic": 8503313,
+        "didokId": "03313",
+        "operator": "SBB",
+        "displayName": "Niederglatt",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 6",
+          "city": "Niederglatt",
+          "postalCode": "8172"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "224"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 53
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. \r\nAufgrund einer Baustelle sind 17 Parkplätze bis auf weiteres nicht zugänglich.",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. \r\nDue to a construction site, 17 parking spaces will not be accessible.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. \r\nA causa di un cantiere, 17 posti auto non saranno accessibili.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. \r\nEn raison d'un chantier, 17 places de parking seront inaccessibles."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d471c28d-42a2-40e9-917c-8b37037ccea1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.510284790367992,
+          47.470904123275716
+        ]
+      },
+      "properties": {
+        "uic": 8503312,
+        "didokId": "03312",
+        "operator": "SBB",
+        "displayName": "Oberglatt",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Kaiserstuhlstrasse 25",
+          "city": "Oberglatt",
+          "postalCode": "8154"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 200
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "440"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 174
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "48ac2871-3b19-44bc-9da6-6f13bc5fb8e4",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.529709276735957,
+          46.85497613569509
+        ]
+      },
+      "properties": {
+        "uic": 8509000,
+        "didokId": "09000",
+        "operator": "SBB",
+        "displayName": "Chur",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Gürtelstrasse 48",
+          "city": "Chur",
+          "postalCode": "7000"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1200,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 200
+            }
+          ],
+          "monthlyTicketPrice": 12000,
+          "yearlyTicketPrice": 120000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "463"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 119
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Zufahrt Gürtelstrasse bis Herbst 2024 nur in einer Richtung befahrbar.\nEinfahrt Parkhaus: Gürtelstrasse 48.",
+          "en": "Gürtelstrasse access road only passable in one direction until autumn 2024.\nEntrance to the car park: Gürtelstrasse 48.",
+          "it": "La strada di accesso alla Gürtelstrasse è percorribile solo in una direzione fino all'autunno 2024.\nEntrata autosilo: Gürtelstrasse 48.",
+          "fr": "Accès à la Gürtelstrasse dans un seul sens jusqu'à l'automne 2024.\nEntrée parking souterrain: Gürtelstrasse 48."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "3c02e4d0-9201-4edd-9716-a5b924fd8567",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.894791893254023,
+          46.442777024336316
+        ]
+      },
+      "properties": {
+        "uic": 8501203,
+        "didokId": "01203",
+        "operator": "SBB",
+        "displayName": "Clarens",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rue de Collège 7",
+          "city": "Clarens",
+          "postalCode": "1815"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 80
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "07:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "295"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 47
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "54095d78-3f01-43f0-ad14-c347db108868",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.39371449588709,
+          47.12007177035006
+        ]
+      },
+      "properties": {
+        "uic": 8502201,
+        "didokId": "02201",
+        "operator": "SBB",
+        "displayName": "Gisikon-Root",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 36",
+          "city": "Gisikon-Root",
+          "postalCode": "6037"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "254"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 29
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ea970529-c3b8-4b51-83d6-14d19e916916",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.368406951494014,
+          47.51183797287928
+        ]
+      },
+      "properties": {
+        "uic": 8503319,
+        "didokId": "03319",
+        "operator": "SBB",
+        "displayName": "Niederweningen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Wehntalerstrasse 71",
+          "city": "Niederweningen",
+          "postalCode": "8166"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "230"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 82
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e511d897-336a-45a7-b32b-989934a51846",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.267483445309159,
+          46.4186339796186
+        ]
+      },
+      "properties": {
+        "uic": 8501031,
+        "didokId": "01031",
+        "operator": "SBB",
+        "displayName": "Gland",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Route de Nyon 1",
+          "city": "Gland",
+          "postalCode": "1196"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "271"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 164
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 5
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "0ba76f4b-d8ba-4692-bb72-8e42fad1dada",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.524167279337965,
+          47.54913647514174
+        ]
+      },
+      "properties": {
+        "uic": 8503401,
+        "didokId": "03401",
+        "operator": "SBB",
+        "displayName": "Glattfelden",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Stationsstrasse 687",
+          "city": "Glattfelden",
+          "postalCode": "8192"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "274"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 63
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "a754ff83-4ca4-42e9-b42b-38d8db21a566",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.138075292001881,
+          47.13904296989131
+        ]
+      },
+      "properties": {
+        "uic": 8502008,
+        "didokId": "02008",
+        "operator": "SBB",
+        "displayName": "Nottwil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 3",
+          "city": "Nottwil",
+          "postalCode": "6207"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "206"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 10
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "48b417a7-45c7-48e8-a0eb-e5092060e42f",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.979098852935679,
+          47.35625844683694
+        ]
+      },
+      "properties": {
+        "uic": 8502111,
+        "didokId": "02111",
+        "operator": "SBB",
+        "displayName": "Däniken",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 1",
+          "city": "Däniken",
+          "postalCode": "4658"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 400
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "249"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 32
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "95c2c1cd-da75-48f4-8d23-36748cdbb175",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.071731349236629,
+          47.03920579112203
+        ]
+      },
+      "properties": {
+        "uic": 8503230,
+        "didokId": "03230",
+        "operator": "SBB",
+        "displayName": "Glarus",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Schweizerhofstrasse 1",
+          "city": "Glarus",
+          "postalCode": "8750"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "261"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 86
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "2da60558-b53f-4978-99d6-768331e493dc",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.404472697037562,
+          47.16578251789646
+        ]
+      },
+      "properties": {
+        "uic": 8502219,
+        "didokId": "02219",
+        "operator": "SBB",
+        "displayName": "Oberrüti",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 23",
+          "city": "Oberrüti",
+          "postalCode": "5647"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "321"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "5336c79b-eaac-460d-994b-6f7131217dbd",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.541252130649856,
+          46.52815434839194
+        ]
+      },
+      "properties": {
+        "uic": 8501045,
+        "didokId": "01045",
+        "operator": "SBB",
+        "displayName": "Denges-Echandens",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Route de la Gare 32",
+          "city": "Denges-Echandens",
+          "postalCode": "1026"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "272"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 13
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "f23ae89f-cc1b-4052-9ac1-a7be4944667c",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.254833206568327,
+          47.41152238877853
+        ]
+      },
+      "properties": {
+        "uic": 8506210,
+        "didokId": "06210",
+        "operator": "SBB",
+        "displayName": "Gossau SG",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Sportstrasse 5",
+          "city": "Gossau SG",
+          "postalCode": "9200"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "15"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 225
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Parkplätze 4-44 sind nur mit Parktickets aus den Automaten gültig, nicht mit SBB-Parkkarte.\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.  ",
+          "en": "For the parking spaces 4-44 only parktickets from the parking meter are accepted, no P+Rail card from the SBB.\r\nThis parking cash register has retired. But its successor, the P+R App, can do much more.   ",
+          "it": "Per gli stalli da 4 a 44 valgono solo gli scontrini emessi dal parcometro, nessun parcheggio con la tessera P+Rail FFS.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.   \r\n ",
+          "fr": "Pour les places 4-44, seuls les ticket de l'horodateur sont valables, pas de stationnement avec carte P+Rail CFF.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "77dd8b1a-9cbf-410e-b32b-65ca53c46642",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.292608807439464,
+          47.608341977577325
+        ]
+      },
+      "properties": {
+        "uic": 8506124,
+        "didokId": "06124",
+        "operator": "SBB",
+        "displayName": "Güttingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 52",
+          "city": "Güttingen",
+          "postalCode": "8594"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "4"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ec02364e-2e0e-48e8-8c1b-21e561ee3d0b",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.362217595608169,
+          46.91423005595834
+        ]
+      },
+      "properties": {
+        "uic": 8504117,
+        "didokId": "04117",
+        "operator": "SBB",
+        "displayName": "Oberwangen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Freiburgstrasse 744",
+          "city": "Oberwangen",
+          "postalCode": "3173"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 400
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "07:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "301"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 7
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "480c0627-836c-43e8-add6-c46dbf282753",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.219103643528968,
+          46.17306501983053
+        ]
+      },
+      "properties": {
+        "uic": 8501503,
+        "didokId": "01503",
+        "operator": "SBB",
+        "displayName": "Riddes",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Place de la Gare 4",
+          "city": "Riddes",
+          "postalCode": "1908"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": null
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 18
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "e7144927-9450-4d2d-81cc-652d3e98c406",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.839164379317866,
+          47.3007103826809
+        ]
+      },
+      "properties": {
+        "uic": 8503130,
+        "didokId": "03130",
+        "operator": "SBB",
+        "displayName": "Hinwil",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 3",
+          "city": "Hinwil",
+          "postalCode": "8340"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "345"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 48
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more.  ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "86ce1ef5-c8c2-4df9-ab15-e2eecbfd970a",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.561592643363253,
+          47.42919950341537
+        ]
+      },
+      "properties": {
+        "uic": 8503340,
+        "didokId": "03340",
+        "operator": "SBB",
+        "displayName": "Opfikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Giebeleichstrasse 20",
+          "city": "Opfikon",
+          "postalCode": "8152"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "231"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 55
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "a302eb77-7596-4fec-8c99-f024e7616ca0",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.403787118542263,
+          47.40753735611524
+        ]
+      },
+      "properties": {
+        "uic": 8503508,
+        "didokId": "03508",
+        "operator": "SBB",
+        "displayName": "Dietikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Weiningerstrasse 1",
+          "city": "Dietikon",
+          "postalCode": "8953"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "416"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 96
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "7 weitere Parkplätze an der Nötzliwiese",
+          "en": "7 additional parking spaces at the Nötzliwiese",
+          "it": "7 parcheggi supplementari presso il Nötzliwiese",
+          "fr": "7 places de parking supplémentaires à la Nötzliwiese"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "f0bdca65-b022-4e0a-bf64-ab848e750eb3",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.462278929321842,
+          47.091670658828455
+        ]
+      },
+      "properties": {
+        "uic": 8505003,
+        "didokId": "05003",
+        "operator": "SBB",
+        "displayName": "Immensee",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Artherstrasse 125",
+          "city": "Immensee",
+          "postalCode": "6405"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "368"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "63456cd8-5cc0-4bb5-b050-aaa570157914",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.6107818633026305,
+          47.49104661600322
+        ]
+      },
+      "properties": {
+        "uic": 8500118,
+        "didokId": "00118",
+        "operator": "SBB",
+        "displayName": "Dornach-Arlesheim",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 8",
+          "city": "Dornach-Arlesheim",
+          "postalCode": "4144"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 200
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "241"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 45
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "12 oberirdische Parkplätze und 33 Parkplätze in der Tiefgarage.\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "12 overground parking spaces and 33 underground parking spaces.\r\nThe parking meter is retired. But the P+Rail app can do much more.",
+          "it": "12 posti all'aperto, 33 posti sotterranei.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "12 places en surface et 33 places en souterrain.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ffe7e231-d2f6-4752-9d26-b1658b1253a6",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.845971451492588,
+          47.54783822472081
+        ]
+      },
+      "properties": {
+        "uic": 8506019,
+        "didokId": "06019",
+        "operator": "SBB",
+        "displayName": "Islikon",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Hauptstrasse 63",
+          "city": "Islikon (Gachnang)",
+          "postalCode": "8546"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "381"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 35
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "65e9639d-49fe-4606-8668-f28ec25d32e7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.799912133804715,
+          47.31522345582912
+        ]
+      },
+      "properties": {
+        "uic": 8500214,
+        "didokId": "00214",
+        "operator": "SBB",
+        "displayName": "Egerkingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 1",
+          "city": "Egerkingen",
+          "postalCode": "4622"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "147"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 31
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "The parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "bdf8998f-117f-47b1-8859-49bbf442d23a",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.193366328123547,
+          46.97617648924452
+        ]
+      },
+      "properties": {
+        "uic": 8504400,
+        "didokId": "04400",
+        "operator": "SBB",
+        "displayName": "Kerzers",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 8",
+          "city": "Kerzers",
+          "postalCode": "3210"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 300
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "44"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 60
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "570da2e4-1efc-48f1-90f9-a1243be73462",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.8377026633266205,
+          46.541147718524634
+        ]
+      },
+      "properties": {
+        "uic": 8504014,
+        "didokId": "04014",
+        "operator": "SBB",
+        "displayName": "Palézieux",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rue de la Gare 22",
+          "city": "Palézieux",
+          "postalCode": "1607"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "397"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 183
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 5
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "b430c026-be3c-439e-93e5-2434146ea526",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.581746266644068,
+          47.44776586976032
+        ]
+      },
+      "properties": {
+        "uic": 8503308,
+        "didokId": "03308",
+        "operator": "SBB",
+        "displayName": "Kloten",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Lindenstrasse 1",
+          "city": "Kloten",
+          "postalCode": "8302"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 150
+            },
+            {
+              "startingFrom": 120,
+              "price": 50
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "222"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 48
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "2f8db5e1-3096-4e49-abe2-a11c36b4e3de",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.026091217172127,
+          47.336128854804144
+        ]
+      },
+      "properties": {
+        "uic": 8502101,
+        "didokId": "02101",
+        "operator": "SBB",
+        "displayName": "Kölliken",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 6",
+          "city": "Kölliken",
+          "postalCode": "5742"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "435"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "9d491f59-bace-468f-bb06-63f44c934073",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.776771519689563,
+          47.20296029121825
+        ]
+      },
+      "properties": {
+        "uic": 8503209,
+        "didokId": "03209",
+        "operator": "SBB",
+        "displayName": "Pfäffikon SZ",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnweg 4",
+          "city": "Pfäffikon SZ",
+          "postalCode": "8808"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "396"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 178
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten stehen bis Ende 2025 weniger Parkplätze zur Verfügung.  ",
+          "en": "Due to construction work, fewer parking spaces will be available until the end of 2025.",
+          "it": "A causa di lavori di costruzione, ci saranno meno posti auto disponibili fino alla fine del 2025. ",
+          "fr": "En raison de travaux de construction, il y aura moins de places de stationnement disponibles jusqu'à la fin de 2025."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "7999711b-3621-4730-814f-1da385ca2d17",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.466737894670452,
+          47.21989725224514
+        ]
+      },
+      "properties": {
+        "uic": 8502226,
+        "didokId": "02226",
+        "operator": "SBB",
+        "displayName": "Knonau",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Chamstrasse 31",
+          "city": "Knonau",
+          "postalCode": "8934"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "325"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 91
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "66b424cf-563b-47e5-9b7b-56b385db8d50",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.785781209375994,
+          47.36627804164278
+        ]
+      },
+      "properties": {
+        "uic": 8503301,
+        "didokId": "03301",
+        "operator": "SBB",
+        "displayName": "Pfäffikon ZH",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 19",
+          "city": "Pfäffikon ZH",
+          "postalCode": "8330"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "436"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 86
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Parken mit Abos ist nur auf der Anlage Süd möglich. Auf der Anlage Nord ist nur Kurzeitparking möglich.  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "Parking with travelcards is only possible in the south car park. Only short-stay parking is permitted in the north car park.  This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Con gli abbonamenti è possibile parcheggiare solo nell’impianto Sud. L’impianto Nord è previsto solo per soste di breve durata.  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Le stationnement avec abonnements n’est possible que sur le parking sud. Sur la partie nord du parking, seul le stationnement de courte durée est possible.  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "c0b66636-73ee-482b-8fb8-e658001cf855",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.22640789018679,
+          47.599191844724075
+        ]
+      },
+      "properties": {
+        "uic": 8500329,
+        "didokId": "00329",
+        "operator": "SBB",
+        "displayName": "Koblenz",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 55",
+          "city": "Koblenz",
+          "postalCode": "5322"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "157"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 113
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 1
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten wird ein Teil der P+Rail-Anlage bis im Frühling 2025 gesperrt sein.\n",
+          "en": "Due to construction work, part of the P+Rail facility will be closed until spring 2025.",
+          "it": "A causa dei lavori di costruzione, una parte della struttura P+Rail rimarrà chiusa fino alla primavera del 2025.",
+          "fr": "En raison de travaux, une partie du P+Rail sera fermée jusqu'au printemps 2025."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "9b7100e6-6d93-4685-b57f-c23f698b8ea4",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.689326916557993,
+          47.522619043895745
+        ]
+      },
+      "properties": {
+        "uic": 8500021,
+        "didokId": "00021",
+        "operator": "SBB",
+        "displayName": "Pratteln",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 19",
+          "city": "Pratteln",
+          "postalCode": "4133"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "197"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 58
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Jetzt herunterladen unter www.sbb.ch/parking",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "ffdf93b8-dbd7-4087-979d-40a9244e3020",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.622095664640596,
+          46.88123187480441
+        ]
+      },
+      "properties": {
+        "uic": 8508202,
+        "didokId": "08202",
+        "operator": "SBB",
+        "displayName": "Konolfingen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Burgdorfstrasse 8",
+          "city": "Konolfingen",
+          "postalCode": "3510"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "352"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 64
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "8bf5f03e-3513-43db-a448-f41cb43a35f4",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.820160239988535,
+          47.22547261393499
+        ]
+      },
+      "properties": {
+        "uic": 8503110,
+        "didokId": "03110",
+        "operator": "SBB",
+        "displayName": "Rapperswil SBB P+Rail",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Güterstrasse 777",
+          "city": "Rapperswil",
+          "postalCode": "8640"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1000,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            },
+            {
+              "startingFrom": 60,
+              "price": 150
+            },
+            {
+              "startingFrom": 120,
+              "price": 250
+            }
+          ],
+          "monthlyTicketPrice": 10000,
+          "yearlyTicketPrice": 100000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "333"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 178
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 3
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 2
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund des Seenachtsfest ist das P+Rail vom 9.-11. August gesperrt.",
+          "en": "Due to the Seenachtsfest, the P+Rail will be closed from 9-11 August.",
+          "it": "A causa della Seenachtsfest, il P+Rail sarà chiuso dal 9 all'11 agosto.",
+          "fr": "En raison de la fête du lac, le P+Rail sera fermé du 9 au 11 août."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": {
+          "eChargingStationOperatorID": "30bd1b8b-b1a6-4957-9d02-eb607c1f9ec2",
+          "eChargingStationOperatorName": "swisscharge",
+          "eChargingStationOperatorLink": "https://map.swisscharge.ch/"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "9540374d-e15b-426a-aafb-7fa3c9c05ea1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.851398772085917,
+          47.189957297087744
+        ]
+      },
+      "properties": {
+        "uic": 8503220,
+        "didokId": "03220",
+        "operator": "SBB",
+        "displayName": "Lachen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofplatz 1",
+          "city": "Lachen SZ",
+          "postalCode": "8853"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 700,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 7000,
+          "yearlyTicketPrice": 70000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "167"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 77
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "b1cd88ad-3cf5-4572-b1bf-41712eda4739",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.553999425600455,
+          46.96808641986071
+        ]
+      },
+      "properties": {
+        "uic": 8509002,
+        "didokId": "09002",
+        "operator": "SBB",
+        "displayName": "Landquart (SBB)",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Lagerhausstrasse",
+          "city": "Landquart",
+          "postalCode": "7302"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "60"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 80
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund eines Umbaus können zurzeit keine Jahresparkkarten gekauft werden.  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "Due to a renovation, annual parking cards cannot be purchased at the moment.  This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "A causa di una ristrutturazione, al momento non è possibile acquistare tessere di parcheggio annuali.  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "En raison d'une transformation, il n'est actuellement pas possible d'acheter des cartes de stationnement annuelles.  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "64ab0a91-b60a-4903-81df-b0a291f02892",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.502437333384413,
+          47.41813335181629
+        ]
+      },
+      "properties": {
+        "uic": 8500113,
+        "didokId": "00113",
+        "operator": "SBB",
+        "displayName": "Laufen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Ziegeleistrasse 28",
+          "city": "Laufen",
+          "postalCode": "4242"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "237"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 97
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 4
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten ist das Parkplatzangebot von September 2024 bis Februar 2025 leicht eingeschränkt.",
+          "en": "Due to construction work, car parking will be slightly restricted from September 2024 to February 2025.\n",
+          "it": "A causa dei lavori di costruzione, il parcheggio sarà leggermente limitato da settembre 2024 a febbraio 2025.\n",
+          "fr": "En raison de travaux, l'offre de stationnement sera légèrement limitée de septembre 2024 à février 2025.\n"
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "689be072-5382-4332-9370-60c605fe02d7",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.839421881156744,
+          46.441567424281004
+        ]
+      },
+      "properties": {
+        "uic": 8505205,
+        "didokId": "05205",
+        "operator": "SBB",
+        "displayName": "Lavorgo",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Nucleo Lavorgo 2",
+          "city": "Lavorgo",
+          "postalCode": "6746"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "73"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 10
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "461788dc-1dda-4885-bad1-a782caa4684e",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.726769939251809,
+          47.05016642283725
+        ]
+      },
+      "properties": {
+        "uic": 8504317,
+        "didokId": "04317",
+        "operator": "SBB",
+        "displayName": "Le Locle Col-des-Roches",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Le Col 5",
+          "city": "Le Locle Col-des-Roches",
+          "postalCode": "2400 "
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "43"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 13
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "869d9822-0b34-406f-94fe-98ba6c2f8305",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.848895154681749,
+          46.14493767726868
+        ]
+      },
+      "properties": {
+        "uic": 8505406,
+        "didokId": "05406",
+        "operator": "SBB",
+        "displayName": "Magadino-Vira",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "La Stazzión 8",
+          "city": "Magadino-Vira (Gambarogno)",
+          "postalCode": "6574"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 500,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "07:00:00",
+          "operatingTo": "19:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "101"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 10
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": null,
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "6a2980a2-4d63-4539-8f02-a240a2d1544f",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.529646928505954,
+          47.00365120230545
+        ]
+      },
+      "properties": {
+        "uic": 8509003,
+        "didokId": "09003",
+        "operator": "SBB",
+        "displayName": "Maienfeld",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Marktgasse 5",
+          "city": "Maienfeld",
+          "postalCode": "7304"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 400,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 4000,
+          "yearlyTicketPrice": 40000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "61"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 16
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "06407557-aeb3-470f-8e52-54e4e386ddec",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.694256686971261,
+          47.252500091296056
+        ]
+      },
+      "properties": {
+        "uic": 8503106,
+        "didokId": "03106",
+        "operator": "SBB",
+        "displayName": "Männedorf",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Bahnhofstrasse 17",
+          "city": "Männedorf",
+          "postalCode": "8708"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "456"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 8
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "d716520e-efc3-4a9a-b14d-5cd2e0116c12",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.080306269844458,
+          46.10564666308653
+        ]
+      },
+      "properties": {
+        "uic": 8501500,
+        "didokId": "01500",
+        "operator": "SBB",
+        "displayName": "Martigny",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Rue de Bellevue 5",
+          "city": "Martigny",
+          "postalCode": "1920"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 1200,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": null,
+          "yearlyTicketPrice": null,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "969"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 36
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.\nDie obigen Angaben beziehen sich ausschliesslich auf die P+Rail Tageskarten.\nMonats- und Jahresabonnemente sind bei der Stadtpolizei Martigny zu lösen. Diese Abos sind ohne Bahnabo erhältlich.",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. .\nDie obigen Angaben beziehen sich ausschliesslich auf die P+Rail Tageskarten.\nMonthly and annual passes sold by the Martigny municipal police. You do not need a travelcard to purchase one of these passes.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. .\nLe informazioni di cui sopra si riferiscono esclusivamente ai biglietti giornalieri P+Rail.\nAbbonamenti mensili e annuali in vendita presso la polizia municipale di Martigny. Questi abbonamenti possono essere ottenuti anche senza abbonamento ferroviario.",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. .\nLes informations ci-dessus se rapportent exclusivement aux cartes journalières P+Rail.\nAbonnements mensuels et annuels en vente à la Police municipale de Martigny. Ces abonnements peuvent être obtenus sans abonnement de train."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "2ac802c7-8775-44b2-9572-9725ecc1b68d",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.64706316482558,
+          47.26874935363567
+        ]
+      },
+      "properties": {
+        "uic": 8503104,
+        "didokId": "03104",
+        "operator": "SBB",
+        "displayName": "Meilen",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Dorfstrasse 154",
+          "city": "Meilen",
+          "postalCode": "8706"
+        },
+        "pricingModel": {
+          "minimumDuration": 240,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 800,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "329"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 28
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten an der Dorfstrasse wird die P+R Anlage von 23. September 2024 bis voraussichtlich 30. November 2024 verschoben. \nDiese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "Due to construction work on the Dorfstrasse, the P+R facility will be postponed from 23 September 2024 until probably 30 November 2024. \nThis parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "A causa dei lavori di costruzione della Dorfstrasse, l'impianto P+R sarà posticipato dal 23 settembre 2024 al 30 novembre 2024. \nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "En raison de travaux de construction dans la Dorfstrasse, le P+R sera déplacé du 23 septembre 2024 au 30 novembre 2024 probablement. \nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "bc024fdc-b367-4aa7-a3f8-11def2338dfb",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.951350966843236,
+          45.954286714637725
+        ]
+      },
+      "properties": {
+        "uic": 8505302,
+        "didokId": "05302",
+        "operator": "SBB",
+        "displayName": "Melide",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Via Cantonale 29",
+          "city": "Melide",
+          "postalCode": "6815"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "92"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 55
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund einer Baustelle gibt es nur ein eingeschränktes Angebot an Abos. Aufgrund von Bauarbeiten stehen ab 01.03.2023 - Ende 2024 eine begrenzten Anzahl an Parkplätzen zur Verfügung.",
+          "en": "Due to a construction site, there is only a limited number of subscriptions available. Due to construction work, a limited number of parking spaces will be available from 01.03.2023 - end of 2024.",
+          "it": "A causa di un cantiere, c'è solo una disponibilità limitata di abbonamenti.\r\nI lavori di costruzione causeranno alcuni disagi agli utenti della stazione. Per far spazio alle installazioni di cantiere parte del P+Rail non sarà agibile fino al termine dei lavori, a fine 2024.",
+          "fr": "En raison d'un chantier, il n'y a qu'une offre limitée d'abonnements. En raison de travaux, un nombre limité de places de parking sera disponible à partir du 01.03.2023 -fin 2024."
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "1a647747-0521-4eb7-89fa-3b1de929adb1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.457396690234741,
+          47.2447018871673
+        ]
+      },
+      "properties": {
+        "uic": 8502225,
+        "didokId": "02225",
+        "operator": "SBB",
+        "displayName": "Mettmenstetten",
+        "publicAccess": true,
+        "address": {
+          "addressLine": "Untere Bahnhofstrasse 20",
+          "city": "Mettmenstetten",
+          "postalCode": "8932"
+        },
+        "pricingModel": {
+          "minimumDuration": 60,
+          "maximumDuration": 10080,
+          "maximumDayPrice": 600,
+          "viableIncrement": 60,
+          "priceSegments": [
+            {
+              "startingFrom": 0,
+              "price": 100
+            }
+          ],
+          "monthlyTicketPrice": 6000,
+          "yearlyTicketPrice": 60000,
+          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
+          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
+        },
+        "operationTime": {
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
+          "daysOfWeek": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
+        },
+        "bookingSystem": {
+          "type": "NOVA",
+          "id": "324"
+        },
+        "capacities": [
+          {
+            "categoryType": "STANDARD",
+            "total": 98
+          },
+          {
+            "categoryType": "DISABLED_PARKING_SPACE",
+            "total": 2
+          },
+          {
+            "categoryType": "RESERVABLE_PARKING_SPACE",
+            "total": 0
+          },
+          {
+            "categoryType": "WITH_CHARGING_STATION",
+            "total": 0
+          }
+        ],
+        "additionalInformationForCustomers": {
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+        },
+        "parkingFacilityCategory": "CAR",
+        "parkingFacilityType": "PARK_AND_RAIL",
+        "salesChannels": [
+          "ONLINE_AND_AUTOMAT"
+        ],
+        "bikeFacilityTraits": [],
+        "eChargingStationOperator": null
+      }
+    },
+    {
+      "type": "Feature",
       "id": "6a8eaf82-42f7-43f0-8d3f-c18a0378f6bb",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.35901046550897,
-          46.22686682885211
+          7.359469018835818,
+          46.226880973980236
         ]
       },
       "properties": {
@@ -758,8 +9661,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.680770983398,
-          47.50658960053
+          8.680341866604882,
+          47.50686706630692
         ]
       },
       "properties": {
@@ -840,8 +9743,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.978840067459,
-          47.216970492685
+          7.9785586575859115,
+          47.21636157497036
         ]
       },
       "properties": {
@@ -1255,8 +10158,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.76038787057,
-          47.465441018991
+          8.760375428294793,
+          47.465552312682696
         ]
       },
       "properties": {
@@ -1342,8 +10245,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.98081,
-          45.8707
+          8.98092905741511,
+          45.870814364530275
         ]
       },
       "properties": {
@@ -1397,7 +10300,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
+            "total": 2
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -1835,94 +10738,12 @@
     },
     {
       "type": "Feature",
-      "id": "fdc39a5f-8d73-46a4-b519-7d6f51a4072d",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.3546881608541,
-          47.3618843699019
-        ]
-      },
-      "properties": {
-        "uic": 8502275,
-        "didokId": "02275",
-        "operator": "AVA",
-        "displayName": "Widen Heinrüti (AVA)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Heinrütiweg ",
-          "city": "Widen",
-          "postalCode": "8967"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "1071"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "0c6fe29f-cdb0-469d-9319-7fb98c1fce6e",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.304581026380208,
-          46.21611496461762
+          7.3041902931788725,
+          46.21635903703031
         ]
       },
       "properties": {
@@ -3907,7 +12728,7 @@
         "uic": 8500159,
         "didokId": "00159",
         "operator": "BLS",
-        "displayName": "Grenchen Nord",
+        "displayName": "Grenchen Nord (BLS)",
         "publicAccess": true,
         "address": {
           "addressLine": " Nordbahnhofstrasse",
@@ -3917,7 +12738,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 800,
+          "maximumDayPrice": 600,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -3986,8 +12807,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.318149,
-          47.595119
+          9.31815683245395,
+          47.59514421213512
         ]
       },
       "properties": {
@@ -4250,8 +13071,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.124923,
-          47.40554
+          7.125016418939577,
+          47.40564589967425
         ]
       },
       "properties": {
@@ -4337,8 +13158,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.364884,
-          46.229087
+          7.364330900172823,
+          46.228543930522534
         ]
       },
       "properties": {
@@ -4419,8 +13240,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.394131217721,
-          47.434692082143
+          9.394243565708434,
+          47.43456462233892
         ]
       },
       "properties": {
@@ -4506,8 +13327,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.750689,
-          47.498573
+          8.750322337365427,
+          47.4987545241548
         ]
       },
       "properties": {
@@ -4593,8 +13414,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.326554,
-          47.569948
+          8.326404706565715,
+          47.569837733303295
         ]
       },
       "properties": {
@@ -4698,7 +13519,7 @@
         "pricingModel": {
           "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 1200,
+          "maximumDayPrice": 1400,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -4860,8 +13681,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.753179955959,
-          47.685223629214
+          8.753892373428965,
+          47.6849981462385
         ]
       },
       "properties": {
@@ -4947,8 +13768,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.48905220098,
-          47.478318382752
+          8.48938984631784,
+          47.47829250469815
         ]
       },
       "properties": {
@@ -5025,99 +13846,12 @@
     },
     {
       "type": "Feature",
-      "id": "c8c7f6ca-150c-4f55-9f6c-8b77dd4504a8",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.551917771689,
-          46.547906715378
-        ]
-      },
-      "properties": {
-        "uic": 8501117,
-        "didokId": "01117",
-        "operator": "SBB",
-        "displayName": "Bussigny",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rue de la Gare 5",
-          "city": "Bussigny",
-          "postalCode": "1030"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "290"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 72
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3ca7b503-e96a-45a0-abd2-f54fd424b0e8",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.607089743445323,
-          46.74607972702074
+          6.607024022629423,
+          46.74597101272482
         ]
       },
       "properties": {
@@ -5198,8 +13932,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.28043344736,
-          46.871822234134
+          7.280469389400164,
+          46.871812503498475
         ]
       },
       "properties": {
@@ -5285,8 +14019,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.214003170045,
-          47.406740165436
+          8.214208912851312,
+          47.40689821522341
         ]
       },
       "properties": {
@@ -5303,7 +14037,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 400,
+          "maximumDayPrice": 500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -5536,8 +14270,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.773456595562,
-          47.458379848705
+          8.773143734393406,
+          47.45857606120483
         ]
       },
       "properties": {
@@ -5618,8 +14352,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.701420880951,
-          47.189003573317
+          7.701767997281783,
+          47.18906022758126
         ]
       },
       "properties": {
@@ -5705,8 +14439,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.339222591332,
-          47.277026874575
+          8.338666289937308,
+          47.27749897448128
         ]
       },
       "properties": {
@@ -5792,8 +14526,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.678058992382,
-          47.259667787008
+          8.678040847235785,
+          47.259549791011665
         ]
       },
       "properties": {
@@ -5874,8 +14608,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.690048,
-          46.503972
+          6.690223866532956,
+          46.503843178238654
         ]
       },
       "properties": {
@@ -5956,8 +14690,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.531662434918,
-          47.207088745949
+          7.53168835953108,
+          47.20712938471564
         ]
       },
       "properties": {
@@ -6212,8 +14946,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.992396,
-          46.320965
+          7.9932764489134716,
+          46.321210352939836
         ]
       },
       "properties": {
@@ -6294,8 +15028,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.512463118524,
-          47.58093128772
+          8.512305924501531,
+          47.580747426414455
         ]
       },
       "properties": {
@@ -6360,7 +15094,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten wird ein Teil der P+Rail Parkplätze bis Mitte November gesperrt sein.",
+          "en": "Due to construction work, a part of the P+Rail parking spaces will be closed until mid-November.",
+          "it": "A causa di lavori di costruzione, una parte dei parcheggi P+Rail sarà chiusa fino a metà novembre.",
+          "fr": "En raison de travaux de construction, une partie des places de parking P+Rail sera fermée jusqu'à mi-novembre."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -6376,8 +15115,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.399270422285481,
-          46.719006040234
+          6.3992303614476205,
+          46.718996646340486
         ]
       },
       "properties": {
@@ -6627,8 +15366,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.897293192799,
-          47.348802090396
+          7.896932774889484,
+          47.34890912732059
         ]
       },
       "properties": {
@@ -6678,7 +15417,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 28
+            "total": 27
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -6796,8 +15535,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.957172,
-          46.829035
+          6.956835280999035,
+          46.82894671237576
         ]
       },
       "properties": {
@@ -6883,8 +15622,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.455617228242,
-          47.177679517829
+          8.455441531918298,
+          47.177658252778635
         ]
       },
       "properties": {
@@ -6950,7 +15689,7 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Während Bauarbeiten stehen vom 02.02.2024 bis 05.07.2024 drei Parkplätze weniger zur Verfügung.  Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
+          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
           "en": "The parking meter is retired. But the P+Rail app can do much more.",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
@@ -6966,268 +15705,12 @@
     },
     {
       "type": "Feature",
-      "id": "2ac802c7-8775-44b2-9572-9725ecc1b68d",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.647132915344,
-          47.268692346196
-        ]
-      },
-      "properties": {
-        "uic": 8503104,
-        "didokId": "03104",
-        "operator": "SBB",
-        "displayName": "Meilen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Dorfstrasse 154",
-          "city": "Meilen",
-          "postalCode": "8706"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "329"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 28
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "192fafcd-2390-4b91-9e02-80b0286d33ac",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.388374939951,
-          47.225163400235
-        ]
-      },
-      "properties": {
-        "uic": 8502217,
-        "didokId": "02217",
-        "operator": "SBB",
-        "displayName": "Mühlau",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Mühlau",
-          "postalCode": "5642"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "449"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "913b36a4-137d-40f5-b15d-d33d9e39c1f6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.631248755156,
-          46.876903862257
-        ]
-      },
-      "properties": {
-        "uic": 8505113,
-        "didokId": "05113",
-        "operator": "SBB",
-        "displayName": "Altdorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 1",
-          "city": "Altdorf",
-          "postalCode": "6460"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "67"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 62
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "b3aab3a9-2ff2-4fe9-b951-9b77029eef87",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.524095357008,
-          47.195703927908
+          8.524581157706281,
+          47.19596483436368
         ]
       },
       "properties": {
@@ -7312,8 +15795,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.675989720624,
-          47.593784875585
+          8.67567305960769,
+          47.593762997424896
         ]
       },
       "properties": {
@@ -7330,28 +15813,30 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 700,
+          "maximumDayPrice": 800,
           "viableIncrement": 60,
           "priceSegments": [
             {
               "startingFrom": 0,
-              "price": 100
+              "price": 150
             }
           ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
         "operationTime": {
-          "operatingFrom": "06:00:00",
-          "operatingTo": "19:00:00",
+          "operatingFrom": "00:00:00",
+          "operatingTo": "00:00:00",
           "daysOfWeek": [
             "MONDAY",
             "TUESDAY",
             "WEDNESDAY",
             "THURSDAY",
-            "FRIDAY"
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
           ]
         },
         "bookingSystem": {
@@ -7479,8 +15964,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.037784240545,
-          46.214531425836
+          6.038315597267725,
+          46.21482977790182
         ]
       },
       "properties": {
@@ -7566,8 +16051,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.436755571025,
-          47.357629978145
+          8.436860002642556,
+          47.35755506121742
         ]
       },
       "properties": {
@@ -7648,8 +16133,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.538323901783,
-          47.523089206016
+          8.537126940219725,
+          47.52392447034935
         ]
       },
       "properties": {
@@ -7719,97 +16204,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Änderung des Parktarifs per 1.1.2024: Tageskarte 8 CHF, Monatsabos 80 CHF, Jahreabos 800 CHF. \n\nDie Parkuhren sind in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.  ",
+          "de": "Die Parkuhren sind in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.  ",
           "en": "The parking meter is retired. But the P+Rail app can do much more.  ",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.  \r\n ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "bbefd5bf-5b53-4714-b89d-854f74aa3caf",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.31886058948,
-          47.099050972193
-        ]
-      },
-      "properties": {
-        "uic": 8504415,
-        "didokId": "04415",
-        "operator": "SBB",
-        "displayName": "Busswil bei Büren",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Busswil bei Büren",
-          "postalCode": "3292"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "51"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 30
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten bis 2023 ist nur ein Teil der Parkplätze verfügbar.\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "Due to construction work until 2023, only part of the parking area is available.\r\nThe parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Per via dei lavori di costruzione dal 2023, solo una parte del parcheggio è disponibile.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.             ",
-          "fr": "En raison de travaux de construction jusqu’à 2023, il y a seulement 28 places de stationnement.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -7826,8 +16224,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.877138412234,
-          46.979537406984
+          6.876864635376929,
+          46.979532349531084
         ]
       },
       "properties": {
@@ -7909,98 +16307,12 @@
     },
     {
       "type": "Feature",
-      "id": "c23edf7e-a81e-4be8-bcb1-0a02e67a5fb7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.469427724606,
-          47.327749086702
-        ]
-      },
-      "properties": {
-        "uic": 8502222,
-        "didokId": "02222",
-        "operator": "SBB",
-        "displayName": "Bonstetten-Wettswil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Stationsstrasse 4",
-          "city": "Bonstetten-Wettswil",
-          "postalCode": "8906"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "07:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "323"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 107
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "An Sonn- und Feiertagen kostenlos.",
-          "en": "Free of charge on Sundays and public holidays.",
-          "it": "Gratuito la domenica e nei giorni festivi.",
-          "fr": "Gratuit les dimanches et jours fériés."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "89e5275f-bab4-4f29-86cf-a2e984c5ec7b",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.183419176652,
-          47.539139370895
+          9.1832453790246,
+          47.539125952035974
         ]
       },
       "properties": {
@@ -8086,8 +16398,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.25233215893,
-          47.442544245668
+          9.252349082807477,
+          47.44268517704956
         ]
       },
       "properties": {
@@ -8137,7 +16449,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 16
+            "total": 8
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -8173,8 +16485,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.619253275919,
-          47.218104960532
+          7.619318080438806,
+          47.218149772306894
         ]
       },
       "properties": {
@@ -8260,8 +16572,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.150273,
-          46.801768
+          7.150594267250404,
+          46.801929983711034
         ]
       },
       "properties": {
@@ -8278,11 +16590,15 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 1200,
+          "maximumDayPrice": 2000,
           "viableIncrement": 60,
           "priceSegments": [
             {
               "startingFrom": 0,
+              "price": 500
+            },
+            {
+              "startingFrom": 60,
               "price": 200
             }
           ],
@@ -8311,7 +16627,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 35
+            "total": 69
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -8327,10 +16643,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Die obrigen Angaben gelten nur für den Parkplatz direkt am Bahnhof Fribourg</b>\r\nParking Ancienne Gare: (24h/24) Plätze nur stunden- oder tageweise, Verkauf mit der P+Rail App, Parkuhr oder am Bahnschalter.Weitere Parkplätze gibt es im Parkhaus der TPF\r\nParking Gare routière unterirdisch</b>\r\nVerkauf Tageskarte «SBB-Kunden» CHF 15.– sowie Monats- und Jahresabos (Öffnungszeiten 05.00-01.00) nur vor Ort im Reisezentrum Freiburg, aktuell verfügbares Kontingent nur für Monatsabonnements.  ",
-          "en": "The above information is only valid for the car park located at the Fribourg railway station</b>\r\nParking Ancienne Gare: (24 hours a day) short-term or daytime parking, sold via the P+R App, parking meter or at the railway station ticket office. Additional parking spaces are available in the TPF car park   \r\n Parking Underground bus station </b>  \r\nDay ticket \"SBB customers\" 15 CHF, monthly and annual season tickets (opening hours 05.00-01.00) Sale only on site in Fribourg, currently only available to monthly pass holders.  ",
-          "it": "Le informazioni riportate sopra sono valide solo per il parcheggio della stazione di Friburgo</b>\r\nParcheggio Ancienne Gare : </b> (24 ore al giorno) parcheggio a breve termine o diurno, venduto tramite l'App P+R, il parchimetro o alla biglietteria della stazione. Ulteriori posti auto sono disponibili nel parcheggio TPF  \r\n Parcheggio alla  stazione degli autobus  </b> \r\nBiglietto giornaliero \"Clienti FFS\" 15 CHF, abbonamenti mensili e annuali (orari di apertura 05.00-01.00) Vendita solo in loco a Friburgo, attualmente disponibile solo per i titolari di abbonamenti mensili.  \r\n ",
-          "fr": "Les informations ci-dessus ne sont valables que pour le parking qui se trouve à la gare de Fribourg</b>\r\nParking Ancienne Gare :\r\n(24h/24) parking courte durée ou à la journée, vendues via l'App P+R, parcmètre ou au guichet de la gare.D'autres places de stationnement sont disponibles dans le parking TPF \r\nParking Gare routière souterraine </b>\r\nCarte journalière \"clients CFF\" 15 CHF, abonnements mensuels et annuels (heures d'ouverture 05.00-01.00) Vente uniquement sur place à Fribourg, actuellement disponible uniquement pour les détenteurs d'un abonnement mensuel.  "
+          "de": "Die obrigen Angaben gelten nur für den Parkplatz direkt am Bahnhof Fribourg\nParking Ancienne Gare: (24h/24) Plätze nur stunden- oder tageweise, Verkauf mit der P+Rail App, Parkuhr oder am Bahnschalter.Weitere Parkplätze gibt es im Parkhaus der TPF\nParking Gare routière unterirdisch\nVerkauf Tageskarte «SBB-Kunden» CHF 20.– sowie Monats- und Jahresabos (Öffnungszeiten 05.00-01.00) nur vor Ort im Reisezentrum Freiburg, aktuell verfügbares Kontingent nur für Monatsabonnements.  ",
+          "en": "The above information is only valid for the car park located at the Fribourg railway station\nParking Ancienne Gare: (24 hours a day) short-term or daytime parking, sold via the P+R App, parking meter or at the railway station ticket office. Additional parking spaces are available in the TPF car park   \n Parking Underground bus station\nDay ticket \"SBB customers\" 20 CHF, monthly and annual season tickets (opening hours 05.00-01.00) Sale only on site in Fribourg, currently only available to monthly pass holders.  ",
+          "it": "Le informazioni riportate sopra sono valide solo per il parcheggio della stazione di Friburgo\nParcheggio Ancienne Gare : </b> (24 ore al giorno) parcheggio a breve termine o diurno, venduto tramite l'App P+R, il parchimetro o alla biglietteria della stazione. Ulteriori posti auto sono disponibili nel parcheggio TPF  \n Parcheggio alla  stazione degli autobus\nBiglietto giornaliero \"Clienti FFS\" 20 CHF, abbonamenti mensili e annuali (orari di apertura 05.00-01.00) Vendita solo in loco a Friburgo, attualmente disponibile solo per i titolari di abbonamenti mensili.  \n ",
+          "fr": "Les informations ci-dessus ne sont valables que pour le parking qui se trouve à la gare de Fribourg\nParking Ancienne Gare :\n(24h/24) parking courte durée ou à la journée, vendues via l'App P+R, parcmètre ou au guichet de la gare.D'autres places de stationnement sont disponibles dans le parking TPF \nParking Gare routière souterraine\nCarte journalière \"clients CFF\" 20 CHF, abonnements mensuels et annuels (heures d'ouverture 05.00-01.00) Vente uniquement sur place à Fribourg, actuellement disponible uniquement pour les détenteurs d'un abonnement mensuel.  "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -8347,8 +16663,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.318823372877,
-          46.888645647436
+          7.318971040772109,
+          46.88865931612464
         ]
       },
       "properties": {
@@ -8419,88 +16735,6 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "95c2c1cd-da75-48f4-8d23-36748cdbb175",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.071728675008,
-          47.039305357681
-        ]
-      },
-      "properties": {
-        "uic": 8503230,
-        "didokId": "03230",
-        "operator": "SBB",
-        "displayName": "Glarus",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Schweizerhofstrasse 1",
-          "city": "Glarus",
-          "postalCode": "8750"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "261"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 86
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -8757,262 +16991,6 @@
           "it": "Carte mensili e annuali valevoli anche a Burgistein e Seftigen.",
           "fr": "Abo mensuels et annuels aussi valables à Burgistein et Seftigen."
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "1b4cff0c-57d4-4a0e-bafb-a7a246f530c4",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.277628800594,
-          47.043399139703
-        ]
-      },
-      "properties": {
-        "uic": 8504404,
-        "didokId": "04404",
-        "operator": "SBB",
-        "displayName": "Aarberg",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 6",
-          "city": "Aarberg",
-          "postalCode": "3270"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "45"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 25
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "986fb329-0bb2-4738-9854-914b3ddc1c99",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.906982181545,
-          47.321093325044
-        ]
-      },
-      "properties": {
-        "uic": 8502000,
-        "didokId": "02000",
-        "operator": "SBB",
-        "displayName": "Aarburg-Oftringen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 2",
-          "city": "Aarburg-Oftringen",
-          "postalCode": "4663"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "202"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 25
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "3b77f3b0-b1df-4fd2-9788-01f8627c6120",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.76661340846,
-          47.335769622305
-        ]
-      },
-      "properties": {
-        "uic": 8503124,
-        "didokId": "03124",
-        "operator": "SBB",
-        "displayName": "Aathal-Seegräben",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Gstalderstrasse 4",
-          "city": "Aathal-Seegräben",
-          "postalCode": "8607"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "340"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 32
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -9699,8 +17677,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.414943121565,
-          47.474128030136
+          9.414938423977796,
+          47.47411857230794
         ]
       },
       "properties": {
@@ -9717,7 +17695,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 400,
+          "maximumDayPrice": 500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -9725,8 +17703,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -9782,94 +17760,12 @@
     },
     {
       "type": "Feature",
-      "id": "570da2e4-1efc-48f1-90f9-a1243be73462",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.837384018316,
-          46.541256981022
-        ]
-      },
-      "properties": {
-        "uic": 8504014,
-        "didokId": "04014",
-        "operator": "SBB",
-        "displayName": "Palézieux",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rue de la Gare 22",
-          "city": "Palézieux",
-          "postalCode": "1607"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "397"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 183
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 5
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3fd55fab-7ffb-413d-9f58-b3b9baf159ac",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.163821132016,
-          47.415636497981
+          8.163821518801015,
+          47.415639391879594
         ]
       },
       "properties": {
@@ -9935,97 +17831,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+Rail App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "8e8cf5f3-6598-44cf-b970-ce6879d762ce",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.169023217583,
-          47.391463653839
-        ]
-      },
-      "properties": {
-        "uic": 8502119,
-        "didokId": "02119",
-        "operator": "SBB",
-        "displayName": "Lenzburg",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 50",
-          "city": "Lenzburg",
-          "postalCode": "5600"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "252"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 264
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 5
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten eingeschränktes Platzangebot. \nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.  ",
-          "en": "Limited space available due to construction work.\nThe parking meter is retired. But the P+Rail app can do much more.  ",
-          "it": "Spazio limitato disponibile a causa di lavori di costruzione.\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.  \n ",
-          "fr": "En raison de travaux, l'espace disponible est limité.\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  "
+          "de": "Ab Anfang März 2025 ist das P+R in Thalheim aufgrund einer Strassensperrung nicht mehr zugänglich. \nDie Parkuhr ist in Pension. Ihre Nachfolgerin, die P+Rail App, kann aber noch viel mehr.",
+          "en": "Starting in early March 2025, the P+R in Thalheim will no longer be accessible due to a road closure\nThe parking meter is retired. But the P+Rail app can do much more.",
+          "it": "A partire da inizio marzo 2025, il P+R a Thalheim non sarà più accessibile a causa della chiusura della strada.\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "À partir du début mars 2025, le P+R à Thalheim ne sera plus accessible en raison de la fermeture de la route.\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -10042,8 +17851,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.427406457672,
-          47.194874507177
+          7.4295645510628905,
+          47.19527123619832
         ]
       },
       "properties": {
@@ -10129,8 +17938,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.751951,
-          47.235935
+          8.751733766931977,
+          47.23591279097253
         ]
       },
       "properties": {
@@ -10211,8 +18020,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.786054032471,
-          46.938301182369
+          7.786211701365073,
+          46.93802228410805
         ]
       },
       "properties": {
@@ -10385,8 +18194,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.848968591263,
-          46.177677130092
+          8.848741356832717,
+          46.177710993604535
         ]
       },
       "properties": {
@@ -10440,7 +18249,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 2
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -10472,8 +18281,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.578088569906,
-          47.280199099885
+          8.578215532856209,
+          47.27990336829632
         ]
       },
       "properties": {
@@ -10559,8 +18368,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.686018218455,
-          47.424830968737
+          8.685916183746853,
+          47.424655678451415
         ]
       },
       "properties": {
@@ -10646,8 +18455,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.315568177794868,
-          47.30510083089492
+          8.315711566595686,
+          47.30497620220396
         ]
       },
       "properties": {
@@ -10810,8 +18619,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.039898,
-          47.052298
+          7.039457188099166,
+          47.05219022270899
         ]
       },
       "properties": {
@@ -10888,186 +18697,12 @@
     },
     {
       "type": "Feature",
-      "id": "0aca6999-d48d-4c64-af07-90e22fedf367",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.560149941664,
-          46.871496827838
-        ]
-      },
-      "properties": {
-        "uic": 8500552,
-        "didokId": "00552",
-        "operator": "SBB",
-        "displayName": "Münsingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Belpbergstrasse 15",
-          "city": "Münsingen",
-          "postalCode": "3110"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "57"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 74
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "80b76b2c-d28a-4721-88e2-4b7cde553489",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.963839811114,
-          46.315481054134
-        ]
-      },
-      "properties": {
-        "uic": 8501400,
-        "didokId": "01400",
-        "operator": "SBB",
-        "displayName": "Aigle",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Chemin Novassalles 4",
-          "city": "Aigle",
-          "postalCode": "1860"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "314"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 347
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 6
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Verwaltung der Parkplätze der SBB und der Gemeinde\nGemeindeanlage für 30% der Parkplätze nur bis 22 Uhr zugänglich, für die anderen 70% durchgängig offen. Stundentarif: CHF 1.-/Stunde, min. 2 Stunden.  ",
-          "en": "Management of SBB and municipal parking spaces. Municipal access limited to 22 hours for 30% of the parking spaces; 24-hour access for the restHourly rate: CHF 1 per hour, min. 2 hours.  ",
-          "it": "Gestione dei posti FFS e comunali\nAccesso comunale fino alle ore 22 per il 30% dei posti, il restante 70% è accessibile 24h/24Tariffa oraria: CHF 1.-/ora, min. 2 ore.  ",
-          "fr": "Gestion des places CFF et communales\nAccès communal limité à 22h pour 30% des places, pour les autres 70% 24h/24Tarif horaire: CHF 1.-/heure, min. 2 heures.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "ff4fdfc7-313e-4f22-975e-52ce187aba48",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.39933215477,
-          46.475282706922
+          6.399209149045303,
+          46.47525518392375
         ]
       },
       "properties": {
@@ -11149,94 +18784,12 @@
     },
     {
       "type": "Feature",
-      "id": "64ab0a91-b60a-4903-81df-b0a291f02892",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.502184835721,
-          47.418391815215
-        ]
-      },
-      "properties": {
-        "uic": 8500113,
-        "didokId": "00113",
-        "operator": "SBB",
-        "displayName": "Laufen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Ziegeleistrasse 28",
-          "city": "Laufen",
-          "postalCode": "4242"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "237"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 97
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "6f5f4f93-7968-44d7-91d2-d13f90dc62d8",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.615025,
-          47.666077
+          8.614829594804085,
+          47.666146817227435
         ]
       },
       "properties": {
@@ -11322,8 +18875,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.98907765893,
-          47.533325006451
+          7.988830684411752,
+          47.53348766245055
         ]
       },
       "properties": {
@@ -11409,8 +18962,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.849092217197,
-          46.967610458536
+          6.8495334188708545,
+          46.967643316883255
         ]
       },
       "properties": {
@@ -11496,8 +19049,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.552125562566,
-          46.657189349455
+          6.5521832877378445,
+          46.65710033602513
         ]
       },
       "properties": {
@@ -11583,8 +19136,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.188411,
-          47.415921
+          9.188257995601784,
+          47.416105801375245
         ]
       },
       "properties": {
@@ -11665,8 +19218,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.187942133135,
-          46.316699087347
+          6.187878918588103,
+          46.3166008444819
         ]
       },
       "properties": {
@@ -11683,12 +19236,12 @@
         "pricingModel": {
           "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 700,
+          "maximumDayPrice": 1000,
           "viableIncrement": 60,
           "priceSegments": [
             {
               "startingFrom": 0,
-              "price": 100
+              "price": 200
             }
           ],
           "monthlyTicketPrice": 7000,
@@ -11752,8 +19305,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.068121621357,
-          47.175534042807
+          7.068117830963722,
+          47.175511534682904
         ]
       },
       "properties": {
@@ -11839,8 +19392,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.811011,
-          46.610294
+          6.810951560132141,
+          46.61069558837292
         ]
       },
       "properties": {
@@ -11919,8 +19472,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.546330626528,
-          47.049958987091
+          7.546475069856715,
+          47.05000278091614
         ]
       },
       "properties": {
@@ -11970,7 +19523,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 33
+            "total": 32
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -12006,8 +19559,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.545734627647,
-          46.898423910293
+          7.545719071241747,
+          46.89848576285438
         ]
       },
       "properties": {
@@ -12093,8 +19646,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.685271292204,
-          47.56308185326
+          8.685320552073025,
+          47.56310939216455
         ]
       },
       "properties": {
@@ -12180,8 +19733,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.695087483467,
-          47.545510585954
+          8.695407910557176,
+          47.54448467836378
         ]
       },
       "properties": {
@@ -12340,181 +19893,12 @@
     },
     {
       "type": "Feature",
-      "id": "6c1db299-8f0e-4301-8905-d46e77cd90a0",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.846847237295,
-          47.465686233526
-        ]
-      },
-      "properties": {
-        "uic": 8500027,
-        "didokId": "00027",
-        "operator": "SBB",
-        "displayName": "Gelterkinden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 12",
-          "city": "Gelterkinden",
-          "postalCode": "4460"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "232"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 88
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.  The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ffdf93b8-dbd7-4087-979d-40a9244e3020",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.622306927053,
-          46.881189868758
-        ]
-      },
-      "properties": {
-        "uic": 8508202,
-        "didokId": "08202",
-        "operator": "SBB",
-        "displayName": "Konolfingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Burgdorfstrasse 8",
-          "city": "Konolfingen",
-          "postalCode": "3510"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "352"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 64
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "d69e6802-ddc8-4f88-bfd0-22a3d096866f",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.517969217444,
-          46.658277055141
+          6.517938205138197,
+          46.658269463763645
         ]
       },
       "properties": {
@@ -12600,8 +19984,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.202106950996,
-          47.524165705247
+          9.202016802057962,
+          47.524210714761566
         ]
       },
       "properties": {
@@ -12668,93 +20052,6 @@
         ],
         "additionalInformationForCustomers": {
           "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "e7263572-b67e-4983-96df-2d660eb57a87",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.223806036771,
-          47.244669952746
-        ]
-      },
-      "properties": {
-        "uic": 8502029,
-        "didokId": "02029",
-        "operator": "SBB",
-        "displayName": "Mosen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Schwarzenbacherstrasse 2",
-          "city": "Mosen",
-          "postalCode": "6295"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "215"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 15
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
           "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
@@ -12861,8 +20158,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.64282,
-          46.311917
+          7.642432306039224,
+          46.31188137110586
         ]
       },
       "properties": {
@@ -12948,8 +20245,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.928371499336,
-          46.095131288273
+          8.928296233891981,
+          46.09515506882293
         ]
       },
       "properties": {
@@ -13035,8 +20332,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.432435,
-          47.142082
+          8.433198940110834,
+          47.14217868838988
         ]
       },
       "properties": {
@@ -13122,8 +20419,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.493737,
-          47.124859
+          9.49389754898408,
+          47.125001226299716
         ]
       },
       "properties": {
@@ -13205,94 +20502,12 @@
     },
     {
       "type": "Feature",
-      "id": "ea970529-c3b8-4b51-83d6-14d19e916916",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.368352065468,
-          47.511886735632
-        ]
-      },
-      "properties": {
-        "uic": 8503319,
-        "didokId": "03319",
-        "operator": "SBB",
-        "displayName": "Niederweningen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Wehntalerstrasse 71",
-          "city": "Niederweningen",
-          "postalCode": "8166"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "230"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 84
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "92ca4f7d-3083-4277-9efd-091117125c99",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.062268805696,
-          47.122996834234
+          9.062296714277108,
+          47.122936964053835
         ]
       },
       "properties": {
@@ -13374,99 +20589,12 @@
     },
     {
       "type": "Feature",
-      "id": "f23ae89f-cc1b-4052-9ac1-a7be4944667c",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.2536864,
-          47.4114316
-        ]
-      },
-      "properties": {
-        "uic": 8506210,
-        "didokId": "06210",
-        "operator": "SBB",
-        "displayName": "Gossau SG",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Sportstrasse 5",
-          "city": "Gossau SG",
-          "postalCode": "9200"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "15"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 225
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 4
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Parkplätze 4-44 sind nur mit Parktickets aus den Automaten gültig, nicht mit SBB-Parkkarte.\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.  ",
-          "en": "For the parking spaces 4-44 only parktickets from the parking meter are accepted, no P+Rail card from the SBB.\r\nThis parking cash register has retired. But its successor, the P+R App, can do much more.   ",
-          "it": "Per gli stalli da 4 a 44 valgono solo gli scontrini emessi dal parcometro, nessun parcheggio con la tessera P+Rail FFS.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.   \r\n ",
-          "fr": "Pour les places 4-44, seuls les ticket de l'horodateur sont valables, pas de stationnement avec carte P+Rail CFF.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "2fb2c50e-0a59-4147-bc80-79de1756b242",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.954639,
-          46.256085
+          6.954502794178289,
+          46.25624403135356
         ]
       },
       "properties": {
@@ -13548,99 +20676,12 @@
     },
     {
       "type": "Feature",
-      "id": "461788dc-1dda-4885-bad1-a782caa4684e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.72667951695,
-          47.050159625478
-        ]
-      },
-      "properties": {
-        "uic": 8504317,
-        "didokId": "04317",
-        "operator": "SBB",
-        "displayName": "Le Locle Col-des-Roches",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Le Col 5",
-          "city": "Le Locle Col-des-Roches",
-          "postalCode": "2400 "
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "43"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 13
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1a3f86b4-0f5d-4d13-ba0b-60491aca3a89",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.001425893918,
-          46.250962716651
+          7.001505498103585,
+          46.250848187431366
         ]
       },
       "properties": {
@@ -13722,99 +20763,12 @@
     },
     {
       "type": "Feature",
-      "id": "29f733bf-8dab-41d1-8819-5295df317c0b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.503756328906,
-          47.488293295484
-        ]
-      },
-      "properties": {
-        "uic": 8503313,
-        "didokId": "03313",
-        "operator": "SBB",
-        "displayName": "Niederglatt",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 6",
-          "city": "Niederglatt",
-          "postalCode": "8172"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "224"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 53
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. \r\nAufgrund einer Baustelle sind 17 Parkplätze bis auf weiteres nicht zugänglich.",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. \r\nDue to a construction site, 17 parking spaces will not be accessible.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. \r\nA causa di un cantiere, 17 posti auto non saranno accessibili.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. \r\nEn raison d'un chantier, 17 places de parking seront inaccessibles."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a82c3b7b-3fad-4118-b8df-f4ae29e8e69b",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.83182420528,
-          47.561224842917
+          7.831470781493557,
+          47.56114819769114
         ]
       },
       "properties": {
@@ -13899,8 +20853,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.884212,
-          46.983447
+          6.884324602029566,
+          46.9834020777077
         ]
       },
       "properties": {
@@ -13986,8 +20940,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.685944729361,
-          47.369688616245
+          8.68549326118938,
+          47.36996649591762
         ]
       },
       "properties": {
@@ -14052,12 +21006,7 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": {
-          "de": ".\n",
-          "en": ".",
-          "it": ".",
-          "fr": "."
-        },
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -14073,8 +21022,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.723799961308,
-          47.614569935072
+          8.723279614598264,
+          47.61454113850944
         ]
       },
       "properties": {
@@ -14160,8 +21109,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.387984504369,
-          47.455113848965
+          8.38725940902055,
+          47.454900060941355
         ]
       },
       "properties": {
@@ -14247,8 +21196,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.645673204755,
-          47.516174352832
+          8.645553464540798,
+          47.516174546277355
         ]
       },
       "properties": {
@@ -14329,8 +21278,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.472963114294,
-          47.436037858705
+          8.472643692620343,
+          47.43597954481901
         ]
       },
       "properties": {
@@ -14411,8 +21360,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.776819723348,
-          46.1170243
+          8.776894218557128,
+          46.11711500175279
         ]
       },
       "properties": {
@@ -14466,7 +21415,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 0
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -14493,8 +21442,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.248549520377,
-          47.088523448063
+          8.248016185925136,
+          47.08884837628276
         ]
       },
       "properties": {
@@ -14511,7 +21460,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 400,
+          "maximumDayPrice": 500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -14580,8 +21529,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.944413852184,
-          47.225169369871
+          8.944072719505485,
+          47.225168917948245
         ]
       },
       "properties": {
@@ -14667,8 +21616,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.977396,
-          46.818502
+          6.9770298299222935,
+          46.81854821776754
         ]
       },
       "properties": {
@@ -14749,8 +21698,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.456032196365,
-          47.200577785161
+          7.456168731192075,
+          47.20060337718512
         ]
       },
       "properties": {
@@ -14836,8 +21785,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.336802171233,
-          46.463053323823
+          6.337422223528864,
+          46.46319593444551
         ]
       },
       "properties": {
@@ -14923,8 +21872,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.854037269906,
-          47.394675135503
+          8.853791330831234,
+          47.395072351158404
         ]
       },
       "properties": {
@@ -15010,8 +21959,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.1588296,
-          47.3461762
+          8.158847677506712,
+          47.346191134398524
         ]
       },
       "properties": {
@@ -15093,99 +22042,12 @@
     },
     {
       "type": "Feature",
-      "id": "9d491f59-bace-468f-bb06-63f44c934073",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.777292342189,
-          47.202963033812
-        ]
-      },
-      "properties": {
-        "uic": 8503209,
-        "didokId": "03209",
-        "operator": "SBB",
-        "displayName": "Pfäffikon SZ",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnweg 4",
-          "city": "Pfäffikon SZ",
-          "postalCode": "8808"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "396"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 178
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten stehen von Mitte August 2023 bis Mitte September 2024 20 P+Rail Parkplätze weniger zur Verfügung.  ",
-          "en": "Due to construction work, 20 fewer P+Rail parking spaces will be available from mid-August 2023 to mid-September 2024.  ",
-          "it": "A causa dei lavori di costruzione, da metà agosto 2023 a metà settembre 2024 saranno disponibili 20 posti auto P+Rail in meno.  \r\n ",
-          "fr": "En raison de travaux, 20 places de stationnement P+Rail de moins seront disponibles de mi-août 2023 à mi-septembre 2024.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "ad68b13d-3969-45c4-94b2-ea32bd4e8885",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.167163733066,
-          47.451588891066
+          8.167245213529462,
+          47.45150459453097
         ]
       },
       "properties": {
@@ -15267,185 +22129,12 @@
     },
     {
       "type": "Feature",
-      "id": "5c3c676a-ea3c-4fa8-8fac-f1f7c91def4b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.55427,
-          47.308141
-        ]
-      },
-      "properties": {
-        "uic": 8503201,
-        "didokId": "03201",
-        "operator": "SBB",
-        "displayName": "Rüschlikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Weingartenstrasse",
-          "city": "Rüschlikon",
-          "postalCode": "8803"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "160"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 12
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten der Gemeinde ist der Anlageteil seeseitig nicht mehr zugänglich. Bitte benützen Sie die P+Rail-Parkplätze an der Weingartenstrasse. \nDie Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "Due to construction work by the municipality, the lakeside section of the facility is no longer accessible. Please use the P+Rail parking spaces on Weingartenstrasse. The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "A causa di lavori di costruzione da parte del comune, la sezione della struttura sul lago non è più accessibile. Si prega di utilizzare i parcheggi P+Rail sulla Weingartenstrasse. Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "En raison de travaux de construction de la commune, la partie de l'installation située côté lac n'est plus accessible. Veuillez utiliser les parkings P+Rail de la Weingartenstrasse. Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "b430c026-be3c-439e-93e5-2434146ea526",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.581875,
-          47.447845
-        ]
-      },
-      "properties": {
-        "uic": 8503308,
-        "didokId": "03308",
-        "operator": "SBB",
-        "displayName": "Kloten",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Lindenstrasse 1",
-          "city": "Kloten",
-          "postalCode": "8302"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 150
-            },
-            {
-              "startingFrom": 120,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "222"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 48
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1a354adc-047b-4e25-b3b5-5ae5f0f0d982",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.901226,
-          47.1826613
+          8.903226688910442,
+          47.18265940889545
         ]
       },
       "properties": {
@@ -15526,8 +22215,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.45933975893,
-          47.482306851088
+          8.459530943860965,
+          47.482050613470705
         ]
       },
       "properties": {
@@ -15592,7 +22281,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund einer Baustelle sind 3 Parkplätze bis 30.09.2024 nicht zugänglich.",
+          "en": "Due to a construction site, 3 car parks are not accessible until 30.09.2024.",
+          "it": "A causa di un cantiere, 3 parcheggi non saranno accessibili fino alla 30.09.2024.",
+          "fr": "En raison d'un chantier, 3 places de parking sont inaccessibles jusqu'à 30.09.2024."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -15608,8 +22302,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.854586037959,
-          47.656464247669
+          8.854361185835996,
+          47.65656878182456
         ]
       },
       "properties": {
@@ -15690,8 +22384,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.50211,
-          47.241353
+          9.502248151815133,
+          47.241739107549456
         ]
       },
       "properties": {
@@ -15777,8 +22471,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.845380280357,
-          46.922081354108
+          7.845201990828256,
+          46.922060447313065
         ]
       },
       "properties": {
@@ -15864,8 +22558,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.868950455017,
-          47.341821584593
+          7.869145089184142,
+          47.34192619146192
         ]
       },
       "properties": {
@@ -15951,8 +22645,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.568776436176,
-          46.842267078443
+          7.56882327161998,
+          46.84215724431607
         ]
       },
       "properties": {
@@ -16034,99 +22728,12 @@
     },
     {
       "type": "Feature",
-      "id": "77dd8b1a-9cbf-410e-b32b-65ca53c46642",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.292771728311,
-          47.60829661849
-        ]
-      },
-      "properties": {
-        "uic": 8506124,
-        "didokId": "06124",
-        "operator": "SBB",
-        "displayName": "Güttingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 52",
-          "city": "Güttingen",
-          "postalCode": "8594"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "4"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 16
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "b9cd125f-afa7-494b-93d7-ef2ac0284211",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.844226788291,
-          47.436667081682
+          8.84416186970402,
+          47.43670272598475
         ]
       },
       "properties": {
@@ -16212,8 +22819,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.848124830619,
-          47.418261182429
+          8.848183635367148,
+          47.41826185512379
         ]
       },
       "properties": {
@@ -16263,7 +22870,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 21
+            "total": 34
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -16299,8 +22906,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.507535787172,
-          47.173530607491
+          8.508181919217593,
+          47.173616114351894
         ]
       },
       "properties": {
@@ -16386,8 +22993,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.168438,
-          47.652587
+          9.168091820317128,
+          47.6527356496392
         ]
       },
       "properties": {
@@ -16404,7 +23011,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 700,
+          "maximumDayPrice": 800,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -16468,8 +23075,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.806813,
-          46.135077
+          8.806946162611519,
+          46.13511979178838
         ]
       },
       "properties": {
@@ -16546,181 +23153,12 @@
     },
     {
       "type": "Feature",
-      "id": "ffe7e231-d2f6-4752-9d26-b1658b1253a6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.845382472878,
-          47.54753004617
-        ]
-      },
-      "properties": {
-        "uic": 8506019,
-        "didokId": "06019",
-        "operator": "SBB",
-        "displayName": "Islikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Hauptstrasse 63",
-          "city": "Islikon (Gachnang)",
-          "postalCode": "8546"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "381"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 35
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "2da60558-b53f-4978-99d6-768331e493dc",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.40448811052,
-          47.165789204386
-        ]
-      },
-      "properties": {
-        "uic": 8502219,
-        "didokId": "02219",
-        "operator": "SBB",
-        "displayName": "Oberrüti",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 23",
-          "city": "Oberrüti",
-          "postalCode": "5647"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "321"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 16
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3ccdeab9-b814-4a35-9313-eaa66aea1650",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.181588048441,
-          47.038423166726
+          8.18163181065195,
+          47.03846707921967
         ]
       },
       "properties": {
@@ -16737,7 +23175,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 400,
+          "maximumDayPrice": 500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -16806,8 +23244,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.843781523557,
-          46.463483944242
+          6.843935860946995,
+          46.46336919231889
         ]
       },
       "properties": {
@@ -16832,7 +23270,7 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 7000,
+          "monthlyTicketPrice": null,
           "yearlyTicketPrice": 70000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
@@ -16893,8 +23331,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.764989030094,
-          46.493268317749
+          6.764651400142632,
+          46.49304022154957
         ]
       },
       "properties": {
@@ -16979,8 +23417,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.46384703268,
-          47.002455191368
+          7.463801358414865,
+          47.002445755106244
         ]
       },
       "properties": {
@@ -17066,8 +23504,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.563639,
-          47.297065
+          8.563205904192987,
+          47.29747690442684
         ]
       },
       "properties": {
@@ -17132,7 +23570,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Die Anlage ist ab Montag, 26.08.2024 bis am Freitag 10.01.2025 gesperrt.",
+          "en": "The facility will be closed from Monday 26/08/2024 until Friday 10/01/2025.",
+          "it": "La struttura rimarrà chiusa da lunedì 26/08/2024 a venerdì 10/01/2025.",
+          "fr": "L'installation sera fermée du lundi 26.08.2024 au vendredi 10.01.2025."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -17156,7 +23599,7 @@
         "uic": 8519328,
         "didokId": "19328",
         "operator": "RBS",
-        "displayName": "Solothurn (RBS)",
+        "displayName": "Solothurn (RBS, Holunderweg) ",
         "publicAccess": true,
         "address": {
           "addressLine": "Holunderweg",
@@ -17174,8 +23617,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -17203,7 +23646,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
+            "total": 1
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -17312,8 +23755,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.181738,
-          47.649093
+          9.182944008734463,
+          47.648279189791
         ]
       },
       "properties": {
@@ -17395,99 +23838,12 @@
     },
     {
       "type": "Feature",
-      "id": "6a2980a2-4d63-4539-8f02-a240a2d1544f",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.52945245582,
-          47.003786747323
-        ]
-      },
-      "properties": {
-        "uic": 8509003,
-        "didokId": "09003",
-        "operator": "SBB",
-        "displayName": "Maienfeld",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Marktgasse 5",
-          "city": "Maienfeld",
-          "postalCode": "7304"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "61"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 16
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "227245a8-94b7-4831-bcc0-b6b5397c443d",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.58179693366,
-          47.064141953969
+          7.5819327135847185,
+          47.064192211510054
         ]
       },
       "properties": {
@@ -17541,94 +23897,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
             "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "06407557-aeb3-470f-8e52-54e4e386ddec",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.694249201536,
-          47.252505937254
-        ]
-      },
-      "properties": {
-        "uic": 8503106,
-        "didokId": "03106",
-        "operator": "SBB",
-        "displayName": "Männedorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 17",
-          "city": "Männedorf",
-          "postalCode": "8708"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "456"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -17660,8 +23929,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.760539083467,
-          47.508366624692
+          8.760786185312856,
+          47.50857958727254
         ]
       },
       "properties": {
@@ -17742,8 +24011,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.387293287172,
-          47.041713720449
+          7.387038376356803,
+          47.0417500558629
         ]
       },
       "properties": {
@@ -17824,8 +24093,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.592196426343236,
-          47.41214368368748
+          8.59279285218323,
+          47.41202079726314
         ]
       },
       "properties": {
@@ -17850,8 +24119,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
+          "monthlyTicketPrice": 10000,
+          "yearlyTicketPrice": 100000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -17911,8 +24180,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.746793218316,
-          46.30630166769
+          7.746672047940264,
+          46.30621631341931
         ]
       },
       "properties": {
@@ -17993,8 +24262,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.367235771897,
-          47.179736430416
+          7.367291932929161,
+          47.1797637646732
         ]
       },
       "properties": {
@@ -18080,8 +24349,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.103907437365,
-          47.567310767469
+          9.103998531557986,
+          47.56731510493436
         ]
       },
       "properties": {
@@ -18098,7 +24367,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 800,
+          "maximumDayPrice": 1000,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -18106,8 +24375,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -18146,7 +24415,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "-",
+          "en": "-",
+          "it": "-",
+          "fr": "-"
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -18162,8 +24436,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.348859,
-          47.095695
+          9.34863265666188,
+          47.09578955448525
         ]
       },
       "properties": {
@@ -18326,8 +24600,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.036976208598,
-          47.462896364875
+          9.037566493992143,
+          47.46289252558746
         ]
       },
       "properties": {
@@ -18393,10 +24667,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Preise und Online-Ticket nur gültig für Parkplätze im Aussenbereich.   Bis Ende Oktober 2022 aufgrund von Bauarbeiten eingeschränktes Platzangebot.   Weitere Plätze in der WIPA, Preise unter http://www.wipa-parking.ch/home ",
-          "en": "Prices and online ticket are valid for parking spaces in the outdoor area only.  Limited space available until the end of October 2022 due to construction work.   Further parking spaces in the WIPA car park, prices at http://www.wipa-parking.ch/home ",
-          "it": "Prezzi e biglietti online validi unicamente per i parcheggi nell’area esterna.  Spazio disponibile per i parcheggi limitato fino alla 31.10.2022 per via dei lavori di costruzione.  Altri posti presso WIPA, prezzi sul sito http://www.wipa-parking.ch/home ",
-          "fr": "Prix et Online-Ticket seulement valables pour les places de stationnement extérieures.   L'espace dévolu aux places de stationnement est limité jusqu'à la fin octobre 2022 en raison des travaux de construction.   Autres places dans le WIPA, prix sous  http://www.wipa-parking.ch/home"
+          "de": "Preise und Online-Ticket nur gültig für Parkplätze im Aussenbereich. ",
+          "en": "Prices and online ticket are valid for parking spaces in the outdoor area only.",
+          "it": "Prezzi e biglietti online validi unicamente per i parcheggi nell’area esterna. ",
+          "fr": "Prix et Online-Ticket seulement valables pour les places de stationnement extérieures. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -18577,8 +24851,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.901801015128,
-          47.488733028517
+          8.901545904451705,
+          47.488872130322186
         ]
       },
       "properties": {
@@ -19403,170 +25677,6 @@
     },
     {
       "type": "Feature",
-      "id": "86ce1ef5-c8c2-4df9-ab15-e2eecbfd970a",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.561939593848,
-          47.429331893425
-        ]
-      },
-      "properties": {
-        "uic": 8503340,
-        "didokId": "03340",
-        "operator": "SBB",
-        "displayName": "Opfikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Giebeleichstrasse 20",
-          "city": "Opfikon",
-          "postalCode": "8152"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "231"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 55
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "24f6f812-9483-4293-9303-d1af7ed058fd",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.610648866934,
-          47.000060615073
-        ]
-      },
-      "properties": {
-        "uic": 8505007,
-        "didokId": "05007",
-        "operator": "SBB",
-        "displayName": "Brunnen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 46",
-          "city": "Brunnen",
-          "postalCode": "6440"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "66"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 43
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3984f535-48ef-48fd-a6e0-7fdd4511691e",
       "geometry": {
         "type": "Point",
@@ -19740,8 +25850,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.804372132471,
-          47.33145244547
+          8.804386360893869,
+          47.331441865328124
         ]
       },
       "properties": {
@@ -19822,8 +25932,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.631777531213,
-          47.0272303
+          8.631778610676882,
+          47.02724432595284
         ]
       },
       "properties": {
@@ -20078,8 +26188,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.865387790144,
-          46.179307808948
+          8.865498827353516,
+          46.179312322512956
         ]
       },
       "properties": {
@@ -20133,7 +26243,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 0
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -20160,8 +26270,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.125020069906,
-          47.388136894645
+          8.124872601322913,
+          47.388206330536285
         ]
       },
       "properties": {
@@ -20232,88 +26342,6 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "689be072-5382-4332-9370-60c605fe02d7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.839478,
-          46.4412
-        ]
-      },
-      "properties": {
-        "uic": 8505205,
-        "didokId": "05205",
-        "operator": "SBB",
-        "displayName": "Lavorgo",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Nucleo Lavorgo 2",
-          "city": "Lavorgo",
-          "postalCode": "6746"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "73"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 10
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -20571,94 +26599,12 @@
     },
     {
       "type": "Feature",
-      "id": "9540374d-e15b-426a-aafb-7fa3c9c05ea1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.850606552431,
-          47.189769700431
-        ]
-      },
-      "properties": {
-        "uic": 8503220,
-        "didokId": "03220",
-        "operator": "SBB",
-        "displayName": "Lachen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 1",
-          "city": "Lachen SZ",
-          "postalCode": "8853"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "167"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 77
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "cba0d1a4-84b1-4942-ae63-ea169cad1db5",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.436045079693,
-          47.391168998615
+          8.436500926841362,
+          47.39124475330436
         ]
       },
       "properties": {
@@ -20724,10 +26670,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Parkplatz von Juni-September 2024 aufgrund von Bauarbeiten gesperrt.  Zusätzlich zu den 21 P+Rail-Parkplätzen gibt es 5 Parkplätze der Gemeinde Urdorf. Auf diesen Parkplätzen sind die SBB P+Rail-Billette und -Abonnemente nicht gültig.",
-          "en": "P+Rail closed from June-September 2024 due to construction work  In addition to 21 P+Rail parking spaces, there are 5 parking spaces in the municipality of Urdorf. P+Rail tickets and SBB season tickets are not valid in these car parks.",
-          "it": "Parcheggio chiuso da giugno a settembre 2024 per lavori di costruzione.  Oltre ai 21 posti di parcheggio P+Rail, nel comune di Urdorf ci sono 5 posti di parcheggio. I biglietti P+Rail e gli abbonamenti FFS non sono validi in questi parcheggi.",
-          "fr": "Parking fermé de juin à septembre 2024 en raison de travaux de construction.  En plus des 21 places P+Rail, 5 places de parking sont disponibles dans la municipalité d'Urdorf. Les billets P+Rail et les abonnements CFF ne sont pas valables dans ces parkings."
+          "de": "Zusätzlich zu den 21 P+Rail-Parkplätzen gibt es 5 Parkplätze der Gemeinde Urdorf. Auf diesen Parkplätzen sind die SBB P+Rail-Billette und -Abonnemente nicht gültig.",
+          "en": "In addition to 21 P+Rail parking spaces, there are 5 parking spaces in the municipality of Urdorf. P+Rail tickets and SBB season tickets are not valid in these car parks.",
+          "it": "Oltre ai 21 posti di parcheggio P+Rail, nel comune di Urdorf ci sono 5 posti di parcheggio. I biglietti P+Rail e gli abbonamenti FFS non sono validi in questi parcheggi.",
+          "fr": "En plus des 21 places P+Rail, 5 places de parking sont disponibles dans la municipalité d'Urdorf. Les billets P+Rail et les abonnements CFF ne sont pas valables dans ces parkings."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -20744,8 +26690,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.584457349213,
-          47.217463584002
+          7.584399840769048,
+          47.21745643743932
         ]
       },
       "properties": {
@@ -20831,8 +26777,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.794453080357,
-          47.49873429732
+          8.793801379075704,
+          47.49888798161764
         ]
       },
       "properties": {
@@ -20918,8 +26864,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.446870011114,
-          47.045509846559
+          9.447069669316766,
+          47.04538367582993
         ]
       },
       "properties": {
@@ -20936,7 +26882,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 600,
+          "maximumDayPrice": 800,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -20944,8 +26890,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
+          "monthlyTicketPrice": 8000,
+          "yearlyTicketPrice": 80000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -20969,7 +26915,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 302
+            "total": 345
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -21009,8 +26955,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.853004,
-          47.014832
+          6.852945537454028,
+          47.0150458971259
         ]
       },
       "properties": {
@@ -21091,8 +27037,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.791085352115,
-          47.551124713402
+          7.790642159795823,
+          47.550883183879186
         ]
       },
       "properties": {
@@ -21260,8 +27206,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.687136,
-          47.679399
+          8.687154627644174,
+          47.67939584553593
         ]
       },
       "properties": {
@@ -21347,8 +27293,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.027768609193,
-          45.833913448897
+          9.027391505594773,
+          45.83400724161709
         ]
       },
       "properties": {
@@ -21402,89 +27348,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "32a54231-edb0-4c70-a3d9-6bfa2236b177",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.5891885,
-          47.259301260002
-        ]
-      },
-      "properties": {
-        "uic": 8502208,
-        "didokId": "02208",
-        "operator": "SBB",
-        "displayName": "Horgen Oberdorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Oberdorfstrasse 33",
-          "city": "Horgen Oberdorf",
-          "postalCode": "8810"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "446"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 29
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 4
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -21496,10 +27360,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+          "de": "Aufgrund einer Baustelle ist das Parkplatzangebot bis Ende 2025 eingeschränkt\n",
+          "en": "Due to a construction site, car parking is limited until the end of 2025\n",
+          "it": "A causa di un cantiere, il parcheggio è limitato fino alla fine del 2025.\n",
+          "fr": "En raison d'un chantier, l'offre de stationnement est limitée jusqu'à fin 2025.\n"
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -21516,8 +27380,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.931613002655,
-          47.354649887519
+          8.931728239954444,
+          47.35451785780651
         ]
       },
       "properties": {
@@ -21603,8 +27467,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.946410721426,
-          46.007858566747
+          8.946382802780068,
+          46.007752050910334
         ]
       },
       "properties": {
@@ -21658,7 +27522,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 4
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -21670,10 +27534,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Weitere P+Rail-Anlage, neu auch für Abokunden:\r\n- P+Rail Lugano Süd mit Barriere Via Clemente Maraini, 6900 Lugano, 85 Plätze. Einfahrt mit SwissPass (www.sbb.ch/swisspass-parking) oder an der zentralen Parkuhr.\r\n- Lugano Nord: Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "Further P+Rail facility, now also for subscription customers :\r\n- P+Rail Lugano South, Via Clemente Maraini, 6900 Lugano, with 116 spaces with barrier. Payment by SwissPass (www.sbb.ch/en/swisspass-parking) or at the central parking meter.\r\n- Lugano Nord: This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Ulteriore struttura P+Rail, ora anche per i clienti in abbonamento: </b>\r\n- P+Rail Lugano Sud con barriera, via Clemente Maraini, 6900 Lugano, 116 posti pagamento con SwissPass (www.ffs.ch/swisspass-parking) o al parchimetro centrale.  \r\nLugano Nord: Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Autre installation P+Rail, désormais aussi pour les abonnés : \r\n- P+Rail Sud avec barrière, Via Clemente Maraini, 6900 Lugano, 116 places. Paiement avec SwissPass (www.cff.ch/swisspass-parking) ou au parcmètre central.\r\n- Lugano Nord: Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+          "de": "Eingeschränktes Parkplatzangebot auf dem P+Rail Lugano Nord bis 2027 aufgrund einer Baustelle. Da weniger Parkplätze zur Verfügung stehen, steht das P+Rail Nord nur für Kundinnen und Kunden mit Abonnement zur Verfügung. Wenn möglich, empfehlen wir Ihnen, den Bahnhof mit den öffentlichen Verkehrsmitteln zu erreichen. Das P+Rail Süd und das P+Rail an der Via Basilea sind nicht betroffen. \n- P+Rail Lugano Süd mit Schranke, Via Clemente Maraini, 6900 Lugano (116 Plätze):\nBezahlung mit SwissPass (www.cff.ch/swisspass-parking) oder an der zentralen Parkuhr möglich.\n- P+Rail Lugano Nord (79 Plätze):\nNur für Besitzer von P+Rail-Fahrkarten (auf Papier oder über die P+Rail-App) . Jetzt herunterladen: www.cff.ch/parking\nAuf beiden Anlagen sind auch die P+Rail-Abonnemente gültig.",
+          "en": "Limited parking spaces available at P+Rail Lugano Nord until 2027 due to a construction site. As there are fewer parking spaces available, P+Rail Nord is only available to customers with a season ticket. If possible, we recommend travelling to the station by public transport. The P+Rail South and the P+Rail on Via Basilea are not affected. \nFurther P+Rail facility:\n- P+Rail Lugano South with barrier, Via Clemente Maraini, 6900 Lugano (116 spaces).\nPayment possible with SwissPass (www.cff.ch/swisspass-parking) or at the central parking meter.\n- P+Rail Lugano Nord (79 spaces).\nOnly for holders of P+Rail tickets (on paper or via the P+Rail app). Download now: www.cff.ch/parking\n",
+          "it": "Posti auto limitati disponibili presso il P+Rail Lugano Nord fino al 2027 a causa di un cantiere. Dato il numero ridotto di posti auto disponibili, il P+Rail Nord è accessibile solo ai clienti in possesso di un abbonamento. Se possibile, si consiglia di raggiungere la stazione con i mezzi pubblici. Il P+Rail Sud e il P+Rail di Via Basilea non sono interessati. \nUlteriore struttura P+Rail:\n-P+Rail Lugano Sud con barriera, Via Clemente Maraini, 6900 Lugano (116 posti).\nPagamento possibile con SwissPass (www.cff.ch/swisspass-parking) o al parchimetro centrale.\n- P+Rail Lugano Nord (79 posti)\nSolo per i possessori di biglietti P+Rail (cartacei o tramite l'app P+Rail). Scarica ora: www.cff.ch/parking\n",
+          "fr": "Offre de stationnement limitée au P+Rail Lugano Nord jusqu'en 2027 en raison d'un chantier. Comme il y a moins de places de stationnement, le P+Rail Nord n'est disponible que pour les clients ayant un abonnement. Dans la mesure du possible, nous vous recommandons d'utiliser les transports publics pour vous rendre à la gare. Le P+Rail Sud et le P+Rail de la Via Basilea ne sont pas concernés. \n- P+Rail Lugano Sud avec barrière, Via Clemente Maraini, 6900 Lugano (116 places):\nPossible de payer avec SwissPass (www.cff.ch/swisspass-parking) ou au parcmètre central. \n- P+Rail Lugano Nord (79 places): \nPour les possesseurs de billets P+Rail uniquement (papier ou via l’appli P+Rail) . Télécharger maintenant : www.cff.ch/parking "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -21690,8 +27554,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.371362795493,
-          46.71269062522
+          6.371228669689777,
+          46.71257046606373
         ]
       },
       "properties": {
@@ -21701,7 +27565,7 @@
         "displayName": "Vallorbe",
         "publicAccess": true,
         "address": {
-          "addressLine": "Rue de la Gare 29",
+          "addressLine": "Rue de la Gare 30",
           "city": "Vallorbe",
           "postalCode": "1337"
         },
@@ -21777,8 +27641,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.167107,
-          47.195002
+          7.16734985895331,
+          47.19503484799926
         ]
       },
       "properties": {
@@ -21860,99 +27724,12 @@
     },
     {
       "type": "Feature",
-      "id": "d471c28d-42a2-40e9-917c-8b37037ccea1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.510188613422,
-          47.470990083988
-        ]
-      },
-      "properties": {
-        "uic": 8503312,
-        "didokId": "03312",
-        "operator": "SBB",
-        "displayName": "Oberglatt",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Kaiserstuhlstrasse 25",
-          "city": "Oberglatt",
-          "postalCode": "8154"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 200
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "440"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 111
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Ab Juli 2023 bis August 2024 eingeschränktes Platzangebot aufgrund Bauarbeiten.  ",
-          "en": "Limited space available from July 2023 to August 2024 due to construction work.  ",
-          "it": "Spazio limitato disponibile da luglio 2023 ad agosto 2024 a causa di lavori di costruzione.  ",
-          "fr": "À partir de juillet 2023 et jusqu'en août 2024, l'offre de places sera limitée en raison de travaux de construction.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "18788d5e-c2fb-4bab-bc73-101d7419fec0",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.875233,
-          47.047669
+          6.8749181701880655,
+          47.04751272463396
         ]
       },
       "properties": {
@@ -22033,8 +27810,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.823142,
-          47.193867
+          8.823332818833434,
+          47.193913150982254
         ]
       },
       "properties": {
@@ -22120,8 +27897,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.277038275463,
-          47.124109924414
+          7.276073548848799,
+          47.1242255435486
         ]
       },
       "properties": {
@@ -22202,8 +27979,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.602963694512,
-          47.46846975249
+          7.6030648362454984,
+          47.46837082489866
         ]
       },
       "properties": {
@@ -22284,8 +28061,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.643114665607,
-          47.24680815841
+          8.643079357024883,
+          47.24676159054763
         ]
       },
       "properties": {
@@ -22371,8 +28148,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.296532551065,
-          47.587508695141
+          8.296683123604197,
+          47.587400177040024
         ]
       },
       "properties": {
@@ -22453,8 +28230,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.106356,
-          46.816947
+          7.106352081679482,
+          46.81694369910831
         ]
       },
       "properties": {
@@ -22540,8 +28317,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.394480481931,
-          46.93706435395
+          7.394052628696205,
+          46.936825500906444
         ]
       },
       "properties": {
@@ -22627,15 +28404,15 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.463468,
-          46.966807
+          7.4628780706325815,
+          46.96667173233705
         ]
       },
       "properties": {
         "uic": 8516161,
         "didokId": "16161",
         "operator": "SBB",
-        "displayName": "Bern Wankdorf",
+        "displayName": "Bern Wankdorf (P+Rail)",
         "publicAccess": true,
         "address": {
           "addressLine": "Max-Daetwyler-Platz",
@@ -22709,8 +28486,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.37026336536,
-          47.138109547569
+          7.370430596699556,
+          47.13812311184571
         ]
       },
       "properties": {
@@ -22791,8 +28568,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.821776,
-          47.097193
+          6.821281316627115,
+          47.09663165621449
         ]
       },
       "properties": {
@@ -22863,173 +28640,6 @@
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ec02364e-2e0e-48e8-8c1b-21e561ee3d0b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.362220288955,
-          46.914195988031
-        ]
-      },
-      "properties": {
-        "uic": 8504117,
-        "didokId": "04117",
-        "operator": "SBB",
-        "displayName": "Oberwangen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Freiburgstrasse 744",
-          "city": "Oberwangen",
-          "postalCode": "3173"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 400
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "07:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "301"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 7
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "7acae6bc-b851-4d6a-9570-caf85bfb0951",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.5595785135814415,
-          46.93399619164299
-        ]
-      },
-      "properties": {
-        "uic": 8589198,
-        "didokId": "89198",
-        "operator": "RBS",
-        "displayName": "Worbboden (RBS)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhof Worbboden",
-          "city": "Worbboden",
-          "postalCode": "3076  "
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "974"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 20
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -23132,8 +28742,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.15011383684,
-          47.54906161881
+          9.150334051423526,
+          47.54891385525207
         ]
       },
       "properties": {
@@ -23219,8 +28829,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.932936,
-          46.038009
+          8.933147243288877,
+          46.03800716252744
         ]
       },
       "properties": {
@@ -23301,8 +28911,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.209224206676,
-          47.480009195784
+          8.208957790198802,
+          47.47971655460886
         ]
       },
       "properties": {
@@ -23317,9 +28927,9 @@
           "postalCode": "5200"
         },
         "pricingModel": {
-          "minimumDuration": 60,
+          "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 1200,
+          "maximumDayPrice": 1500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -23388,8 +28998,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.842260450332,
-          46.708064292096
+          6.8426292728819655,
+          46.708403759239935
         ]
       },
       "properties": {
@@ -23459,180 +29069,6 @@
           "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "bdf8998f-117f-47b1-8859-49bbf442d23a",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.193332654562,
-          46.976127239191
-        ]
-      },
-      "properties": {
-        "uic": 8504400,
-        "didokId": "04400",
-        "operator": "SBB",
-        "displayName": "Kerzers",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 8",
-          "city": "Kerzers",
-          "postalCode": "3210"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 300
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "44"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 63
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "ffdf67bf-9257-4537-a32c-a6543df5dbfd",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.518804677771,
-          46.697917539129
-        ]
-      },
-      "properties": {
-        "uic": 8501107,
-        "didokId": "01107",
-        "operator": "SBB",
-        "displayName": "Arnex-sur-Orbe",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Route de la Gare 11",
-          "city": "Arnex-sur-Orbe",
-          "postalCode": "1321"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "285"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 21
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Von 26. April 2024 bis Juli 2025 werden mehrere Parkplätze im P+Rail Arnex vorübergehend aufgehoben. \nDie gelegentlichen Benutzer des P+Rail von Arnex werden gebeten, die P+Rail-Parkplätze von La Sarraz und Croy zu benutzen. \nWährend dieser Zeit ist der P+Rail in Arnex ausschließlich für Inhaber eines P+Rail-Abonnements reserviert.",
-          "en": "A number of parking spaces will be temporarily withdrawn from the Arnex P+Rail from April 2024 to July 2025. \nOccasional users of the P+Rail d'Arnex are asked to use the P+Rail car parks at La Sarraz and Croy. \nDuring this period, the Arnex P+Rail is strictly reserved for P+Rail season ticket holders.",
-          "it": "Da aprile 2024 a luglio 2025 saranno temporaneamente ritirati alcuni posti auto dall'Arnex P+Rail. \nGli utenti occasionali del P+Rail d'Arnex sono invitati a utilizzare i parcheggi P+Rail di La Sarraz e Croy. \nDurante questo periodo, l'Arnex P+Rail è strettamente riservato ai titolari di un abbonamento P+Rail.",
-          "fr": "Plusieurs places de parc sont provisoirement supprimées dans le P+Rail d'Arnex de 26 avril 2024 à juillet 2025. \nLes utilisateurs occasionnels du P+Rail d'Arnex sont priés d'utili\u0002ser les parking P+Rail de La Sarraz et de Croy. \nDurant cette période, le P+Rail d'Arnex est strictement réservé aux porteurs d'abonnements P+Rail."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -23903,8 +29339,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.551637270639,
-          47.048163288821
+          8.551497764907664,
+          47.048320659113976
         ]
       },
       "properties": {
@@ -23986,94 +29422,12 @@
     },
     {
       "type": "Feature",
-      "id": "1c29f640-b703-43bd-95e8-36ae28263ef1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.504264469242,
-          47.010293965751
-        ]
-      },
-      "properties": {
-        "uic": 8509004,
-        "didokId": "09004",
-        "operator": "SBB",
-        "displayName": "Bad Ragaz",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Unterrainstrasse 1",
-          "city": "Bad Ragaz",
-          "postalCode": "7310"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "62"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 54
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "f2ba567f-37ad-4fbf-90dd-eaf3bc30ddbd",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.317110268123,
-          47.153718815493
+          8.316878297629048,
+          47.153995446587935
         ]
       },
       "properties": {
@@ -24155,99 +29509,12 @@
     },
     {
       "type": "Feature",
-      "id": "052c9b04-64ff-4ccf-8a1a-fde1bd0d5532",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.201980820307,
-          47.268091213948
-        ]
-      },
-      "properties": {
-        "uic": 8502034,
-        "didokId": "02034",
-        "operator": "SBB",
-        "displayName": "Beinwil am See",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Hombergstrasse 4",
-          "city": "Beinwil am See",
-          "postalCode": "5712"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "217"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 68
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "d3036124-f552-4bdd-b056-f9ae49d9a652",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.974471186578,
-          46.350332979137
+          8.974585871023642,
+          46.349886431522215
         ]
       },
       "properties": {
@@ -24301,7 +29568,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 0
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -24328,8 +29595,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.753011558861,
-          47.553001615932
+          8.752884438016345,
+          47.55281626155226
         ]
       },
       "properties": {
@@ -24415,8 +29682,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.567742666934,
-          46.709455778372
+          6.567637310355453,
+          46.70934705991293
         ]
       },
       "properties": {
@@ -24498,94 +29765,12 @@
     },
     {
       "type": "Feature",
-      "id": "bb78349c-446e-4d40-83ba-9d22756d321e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.437528116008,
-          47.452889467759
-        ]
-      },
-      "properties": {
-        "uic": 8503527,
-        "didokId": "03527",
-        "operator": "SBB",
-        "displayName": "Buchs-Dällikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Furtbachstrasse 4",
-          "city": "Buchs-Dällikon",
-          "postalCode": "8107"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "292"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 57
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "5f354885-b137-46b9-a402-b6031c2993f7",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.775912,
-          47.525728
+          8.77588508178721,
+          47.52577599517107
         ]
       },
       "properties": {
@@ -24671,8 +29856,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.530504990807,
-          47.433588663295
+          7.529928106329813,
+          47.433154821054494
         ]
       },
       "properties": {
@@ -24753,8 +29938,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.067554215275,
-          47.056779451776
+          7.067668739666604,
+          47.0568149211313
         ]
       },
       "properties": {
@@ -24840,8 +30025,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.842698,
-          46.844557
+          6.842828249904217,
+          46.84457761032206
         ]
       },
       "properties": {
@@ -24927,8 +30112,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.771034,
-          47.666313
+          8.77100620873358,
+          47.666321822100244
         ]
       },
       "properties": {
@@ -25014,8 +30199,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.382352,
-          47.544113
+          9.381616783976249,
+          47.54452787391954
         ]
       },
       "properties": {
@@ -25097,94 +30282,12 @@
     },
     {
       "type": "Feature",
-      "id": "77a590da-6201-4e5c-ac0c-9e4c9ad698f8",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.458891,
-          46.978906
-        ]
-      },
-      "properties": {
-        "uic": 8508054,
-        "didokId": "08054",
-        "operator": "RBS",
-        "displayName": "Worblaufen Ost (RBS)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Worblaufenstrasse",
-          "city": "Worblaufen",
-          "postalCode": "3048"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "966"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 10
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "66c8bc21-4bbb-4d76-a81e-d00abfd69da4",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.351803518455,
-          46.893435785759
+          7.351669863416843,
+          46.89346205992629
         ]
       },
       "properties": {
@@ -25357,8 +30460,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.04029009682,
-          46.884096135804
+          7.040190404082328,
+          46.88408540171285
         ]
       },
       "properties": {
@@ -25440,94 +30543,12 @@
     },
     {
       "type": "Feature",
-      "id": "61813d7c-eb57-4a4c-a266-5a35872237f6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.698520768123,
-          46.900147461214
-        ]
-      },
-      "properties": {
-        "uic": 8508204,
-        "didokId": "08204",
-        "operator": "SBB",
-        "displayName": "Bowil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Bowil",
-          "postalCode": "3533"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "23"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 24
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "4f680e26-9c48-40c0-a47e-f3af1df65918",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.907043,
-          46.379918
+          8.906932599398466,
+          46.380005480232235
         ]
       },
       "properties": {
@@ -25581,7 +30602,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 0
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -25608,8 +30629,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.318003452779,
-          47.342992911652
+          7.317963074088049,
+          47.34299627239439
         ]
       },
       "properties": {
@@ -25695,8 +30716,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.89403124107,
-          46.758666461973
+          6.893827860741139,
+          46.758412833933036
         ]
       },
       "properties": {
@@ -25782,8 +30803,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.834108,
-          46.959032
+          6.834410155097322,
+          46.959110952760824
         ]
       },
       "properties": {
@@ -25864,8 +30885,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.44677,
-          47.489948
+          8.446894992871414,
+          47.48982957313251
         ]
       },
       "properties": {
@@ -25946,8 +30967,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.041541579693,
-          46.224794276754
+          9.04154788304358,
+          46.22482029847432
         ]
       },
       "properties": {
@@ -26037,8 +31058,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.240495030025,
-          47.518503407576
+          8.240376136993588,
+          47.51845542787555
         ]
       },
       "properties": {
@@ -26119,8 +31140,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.01652481059,
-          47.588152766658
+          9.016147908761967,
+          47.58824347737501
         ]
       },
       "properties": {
@@ -26201,8 +31222,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.542656370639,
-          47.603579570676
+          8.543044396158377,
+          47.603727461213516
         ]
       },
       "properties": {
@@ -26283,8 +31304,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.198981088361,
-          47.28771075714
+          8.19899564492784,
+          47.28755329110619
         ]
       },
       "properties": {
@@ -26366,180 +31387,12 @@
     },
     {
       "type": "Feature",
-      "id": "5336c79b-eaac-460d-994b-6f7131217dbd",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.541236304577,
-          46.528156065893
-        ]
-      },
-      "properties": {
-        "uic": 8501045,
-        "didokId": "01045",
-        "operator": "SBB",
-        "displayName": "Denges-Echandens",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Route de la Gare 32",
-          "city": "Denges-Echandens",
-          "postalCode": "1026"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "272"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 13
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "3c02e4d0-9201-4edd-9716-a5b924fd8567",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.894889,
-          46.442786
-        ]
-      },
-      "properties": {
-        "uic": 8501203,
-        "didokId": "01203",
-        "operator": "SBB",
-        "displayName": "Clarens",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rue de Collège 7",
-          "city": "Clarens",
-          "postalCode": "1815"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 80
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "07:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "295"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 47
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "544369ea-77c3-4d9d-9b55-9eb64aa20bb0",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.433623,
-          47.509991
+          9.433597186975895,
+          47.50972763577469
         ]
       },
       "properties": {
@@ -26785,99 +31638,12 @@
     },
     {
       "type": "Feature",
-      "id": "c74fda76-3d10-4823-8656-a3aeee96fde6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.365276572947,
-          47.247203492194
-        ]
-      },
-      "properties": {
-        "uic": 8502216,
-        "didokId": "02216",
-        "operator": "SBB",
-        "displayName": "Benzenschwil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 2",
-          "city": "Benzenschwil",
-          "postalCode": "5636"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "320"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 15
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "28c776bf-ced9-4703-a834-78084c7b42c0",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.280019716533,
-          47.185935711868
+          8.279990416805209,
+          47.18592820073349
         ]
       },
       "properties": {
@@ -26963,8 +31729,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.946813903705,
-          47.354431113727
+          7.947022752496911,
+          47.35418060212165
         ]
       },
       "properties": {
@@ -27045,8 +31811,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.862551434849,
-          47.498514294015
+          8.862374410377148,
+          47.49850798231208
         ]
       },
       "properties": {
@@ -27127,8 +31893,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.358314,
-          47.44564
+          8.358566393117869,
+          47.44565349051365
         ]
       },
       "properties": {
@@ -27209,8 +31975,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.342053255156,
-          47.08389942485
+          8.342186103815816,
+          47.08380798246197
         ]
       },
       "properties": {
@@ -27296,8 +32062,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.062755616394,
-          46.99405803854
+          8.062657306057586,
+          46.99398632283702
         ]
       },
       "properties": {
@@ -27379,176 +32145,12 @@
     },
     {
       "type": "Feature",
-      "id": "48b417a7-45c7-48e8-a0eb-e5092060e42f",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.979042539148,
-          47.356259288909
-        ]
-      },
-      "properties": {
-        "uic": 8502111,
-        "didokId": "02111",
-        "operator": "SBB",
-        "displayName": "Däniken",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Däniken",
-          "postalCode": "4658"
-        },
-        "pricingModel": {
-          "minimumDuration": 1440,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 300,
-          "viableIncrement": 1440,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 300
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "249"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 32
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "54095d78-3f01-43f0-ad14-c347db108868",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.393596179098,
-          47.120023651054
-        ]
-      },
-      "properties": {
-        "uic": 8502201,
-        "didokId": "02201",
-        "operator": "SBB",
-        "displayName": "Gisikon-Root",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 36",
-          "city": "Gisikon-Root",
-          "postalCode": "6037"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "254"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 29
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "6935079d-baaa-4f13-a1f5-2ce83941b307",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.618981,
-          47.419755
+          8.618552181511483,
+          47.41898641470356
         ]
       },
       "properties": {
@@ -27634,8 +32236,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.623933337643,
-          47.399734338948
+          8.624348973211417,
+          47.39959186351898
         ]
       },
       "properties": {
@@ -27721,8 +32323,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.649317489024,
-          46.820439531815
+          8.649200263224266,
+          46.82047313340158
         ]
       },
       "properties": {
@@ -27804,273 +32406,12 @@
     },
     {
       "type": "Feature",
-      "id": "6e8cf993-c0db-4cd1-a13d-5b357afc94b7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.113247,
-          46.924608
-        ]
-      },
-      "properties": {
-        "uic": 8504128,
-        "didokId": "04128",
-        "operator": "SBB",
-        "displayName": "Murten",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Freiburgstrasse 14",
-          "city": "Murten",
-          "postalCode": "3280"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 200
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": 9000,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": 90000
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "306"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 74
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "d1e19871-8d37-4347-aa2a-a18a9c575efc",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.750997403774,
-          47.384831729742
-        ]
-      },
-      "properties": {
-        "uic": 8503302,
-        "didokId": "03302",
-        "operator": "SBB",
-        "displayName": "Fehraltorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 37",
-          "city": "Fehraltorf",
-          "postalCode": "8320"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "219"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 78
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "91a9d7e8-b188-4138-89a1-c9fe2b00a00e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.303132737573,
-          47.550281859164
-        ]
-      },
-      "properties": {
-        "uic": 8506109,
-        "didokId": "06109",
-        "operator": "SBB",
-        "displayName": "Amriswil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Poststrasse 6",
-          "city": "Amriswil",
-          "postalCode": "8580"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "137"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 78
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Nordstrasse: 37 Parkplätze\r\nOst: 27 Parkplätze\r\nBahnhofplatz: 14 Parkplätze",
-          "en": "Nordstrasse: 37 parking spaces\r\nOst: 27 parking spaces\r\nBahnhofplatz: 14 parking spaces ",
-          "it": "Nordstrasse: 37 posti de parcheggio\r\nOst: 27 posti de parcheggio\r\nBahnhofplatz: 14 posti de parcheggio",
-          "fr": "Nordstrasse: 37 places\r\nOst: 27 places \r\nBahnhofplatz: 14 places"
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "88dc9514-0f2a-422b-ae86-be7017e13498",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.307455,
-          47.477473
+          8.307513363437392,
+          47.47779051237392
         ]
       },
       "properties": {
@@ -28156,8 +32497,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.626442342992,
-          47.438818089746
+          8.626475221042703,
+          47.4386776931357
         ]
       },
       "properties": {
@@ -28243,8 +32584,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.879025193987,
-          47.368478951946
+          8.87984059606367,
+          47.36841151739587
         ]
       },
       "properties": {
@@ -28330,8 +32671,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.073727584656,
-          46.993835641395
+          9.073812821354071,
+          46.993583596180336
         ]
       },
       "properties": {
@@ -28344,354 +32685,6 @@
           "addressLine": "Hauptstrasse 73",
           "city": "Schwanden",
           "postalCode": "8762"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "262"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 36
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "05804c7d-8b40-442f-b739-57f769e5ccfc",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.936357472422,
-          46.914692317894
-        ]
-      },
-      "properties": {
-        "uic": 8508210,
-        "didokId": "08210",
-        "operator": "SBB",
-        "displayName": "Escholzmatt",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 2",
-          "city": "Escholzmatt",
-          "postalCode": "6182"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "27"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 48
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "70cca348-bcec-4ff6-b50c-4a7793e0970e",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.875809109718,
-          47.645610951323
-        ]
-      },
-      "properties": {
-        "uic": 8506138,
-        "didokId": "06138",
-        "operator": "SBB",
-        "displayName": "Eschenz",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Eschenz",
-          "postalCode": "8264"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "350"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 7
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "1b42fd3a-f242-4083-946c-ae9fff13c24a",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.226444824468,
-          47.551417464598
-        ]
-      },
-      "properties": {
-        "uic": 8506107,
-        "didokId": "06107",
-        "operator": "SBB",
-        "displayName": "Erlen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 2",
-          "city": "Erlen",
-          "postalCode": "8586"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "387"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "94d97311-3042-4362-84e9-2cf0fba9a7c1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.647350717266,
-          47.69161147158
-        ]
-      },
-      "properties": {
-        "uic": 8503425,
-        "didokId": "03425",
-        "operator": "SBB",
-        "displayName": "Feuerthalen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Diessenhoferstrasse 25",
-          "city": "Feuerthalen",
-          "postalCode": "8245"
         },
         "pricingModel": {
           "minimumDuration": 60,
@@ -28724,12 +32717,12 @@
         },
         "bookingSystem": {
           "type": "NOVA",
-          "id": "411"
+          "id": "262"
         },
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 12
+            "total": 21
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -28745,10 +32738,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -28765,8 +32758,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.923042455225,
-          47.333116740037
+          8.92307426670583,
+          47.333061033366164
         ]
       },
       "properties": {
@@ -28852,8 +32845,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.477824012234,
-          46.696884246683
+          6.477876688086246,
+          46.69676451556499
         ]
       },
       "properties": {
@@ -28939,8 +32932,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.989427,
-          46.319104
+          7.990987314532354,
+          46.31931320862403
         ]
       },
       "properties": {
@@ -29186,99 +33179,12 @@
     },
     {
       "type": "Feature",
-      "id": "8ff47646-0791-455f-9a7a-e8d35dd91803",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.280880647885,
-          47.072114545017
-        ]
-      },
-      "properties": {
-        "uic": 8502021,
-        "didokId": "02021",
-        "operator": "SBB",
-        "displayName": "Emmenbrücke",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Schützenmattstrasse 36",
-          "city": "Emmenbrücke",
-          "postalCode": "6020"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "211"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 89
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3aa9e036-53d2-4a5d-8af4-02cc51804119",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.08019298102,
-          47.421702449013
+          7.080212746636129,
+          47.42182752790481
         ]
       },
       "properties": {
@@ -29364,8 +33270,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.380271,
-          47.28068
+          7.381128764071717,
+          47.28040495851434
         ]
       },
       "properties": {
@@ -29430,7 +33336,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten steht bis am 30.06.2025 ein eingeschränktes Parkplatzangebot zur Verfügung.",
+          "en": "Due to construction work, a limited number of parking spaces will be available until 30.06.2025.",
+          "it": "A causa dei lavori di costruzione, sarà disponibile un numero limitato di posti auto fino al 30.06.2025.",
+          "fr": "En raison de travaux de construction, une offre limitée de places de stationnement est disponible jusqu'au 30 juin 2025."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -29446,8 +33357,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.72268965159,
-          47.240149766696
+          8.723509167047926,
+          47.240033573208684
         ]
       },
       "properties": {
@@ -29533,8 +33444,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.818345281545,
-          47.660982718374
+          8.818460600811841,
+          47.661018037087956
         ]
       },
       "properties": {
@@ -29551,7 +33462,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 400,
+          "maximumDayPrice": 500,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -29559,8 +33470,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -29620,8 +33531,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.719327388886,
-          47.50114322635
+          7.719275756439537,
+          47.50113849242124
         ]
       },
       "properties": {
@@ -29707,8 +33618,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.708500106815,
-          47.207337444283
+          8.70859297497797,
+          47.20728290990408
         ]
       },
       "properties": {
@@ -29790,445 +33701,12 @@
     },
     {
       "type": "Feature",
-      "id": "a302eb77-7596-4fec-8c99-f024e7616ca0",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.403552694512,
-          47.407682008549
-        ]
-      },
-      "properties": {
-        "uic": 8503508,
-        "didokId": "03508",
-        "operator": "SBB",
-        "displayName": "Dietikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Weiningerstrasse 1",
-          "city": "Dietikon",
-          "postalCode": "8953"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "416"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 96
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "7 weitere Parkplätze an der Nötzliwiese",
-          "en": "7 additional parking spaces at the Nötzliwiese",
-          "it": "7 parcheggi supplementari presso il Nötzliwiese",
-          "fr": "7 places de parking supplémentaires à la Nötzliwiese"
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "561f74e0-7410-42dd-a5bb-437e49a92905",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.747039983467,
-          46.947345214099
-        ]
-      },
-      "properties": {
-        "uic": 8508206,
-        "didokId": "08206",
-        "operator": "SBB",
-        "displayName": "Emmenmatt",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 135",
-          "city": "Emmenmatt",
-          "postalCode": "3543"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "24"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 16
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "0ba76f4b-d8ba-4692-bb72-8e42fad1dada",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.524322341139,
-          47.549388013913
-        ]
-      },
-      "properties": {
-        "uic": 8503401,
-        "didokId": "03401",
-        "operator": "SBB",
-        "displayName": "Glattfelden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Stationsstrasse 687",
-          "city": "Glattfelden",
-          "postalCode": "8192"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "274"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 63
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "f0bdca65-b022-4e0a-bf64-ab848e750eb3",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.462281430619,
-          47.091695567338
-        ]
-      },
-      "properties": {
-        "uic": 8505003,
-        "didokId": "05003",
-        "operator": "SBB",
-        "displayName": "Immensee",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Artherstrasse 125",
-          "city": "Immensee",
-          "postalCode": "6405"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "368"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 8
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "66b424cf-563b-47e5-9b7b-56b385db8d50",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.785286756393951,
-          47.36672406311088
-        ]
-      },
-      "properties": {
-        "uic": 8503301,
-        "didokId": "03301",
-        "operator": "SBB",
-        "displayName": "Pfäffikon ZH",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 19",
-          "city": "Pfäffikon ZH",
-          "postalCode": "8330"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "436"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 86
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Parken mit Abos ist nur auf der Anlage Süd möglich. Auf der Anlage Nord ist nur Kurzeitparking möglich.  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "Parking with travelcards is only possible in the south car park. Only short-stay parking is permitted in the north car park.  This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Con gli abbonamenti è possibile parcheggiare solo nell’impianto Sud. L’impianto Nord è previsto solo per soste di breve durata.  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Le stationnement avec abonnements n’est possible que sur le parking sud. Sur la partie nord du parking, seul le stationnement de courte durée est possible.  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "91301b92-be54-4a45-a463-5d1a9cc22b71",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.351687881754,
-          47.361237958679
+          7.351638411664496,
+          47.361243950803505
         ]
       },
       "properties": {
@@ -30278,7 +33756,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 120
+            "total": 118
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -30314,8 +33792,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.190313342922,
-          46.85129534728
+          7.190728557541596,
+          46.85163999567051
         ]
       },
       "properties": {
@@ -30392,268 +33870,12 @@
     },
     {
       "type": "Feature",
-      "id": "7e625c16-2be0-4e8e-aac7-4b04818f7f55",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.479728426598,
-          47.167058336275
-        ]
-      },
-      "properties": {
-        "uic": 8509404,
-        "didokId": "09404",
-        "operator": "SBB",
-        "displayName": "Buchs SG",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rheinstrasse 4",
-          "city": "Buchs SG",
-          "postalCode": "9470"
-        },
-        "pricingModel": {
-          "minimumDuration": 240,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "78"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 108
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Tagesparkingtickets können auch am Billettautomaten gekauft werden.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more. Day parking tickets can also be purchased from the ticket machine.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. I biglietti per il parcheggio giornaliero possono essere acquistati anche presso la biglietteria automatica.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. Les tickets de parking à la journée peuvent aussi être achetés aux distributeurs de billets."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "65e9639d-49fe-4606-8668-f28ec25d32e7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.799722098286,
-          47.315154415019
-        ]
-      },
-      "properties": {
-        "uic": 8500214,
-        "didokId": "00214",
-        "operator": "SBB",
-        "displayName": "Egerkingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 1",
-          "city": "Egerkingen",
-          "postalCode": "4622"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "147"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 31
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "e511d897-336a-45a7-b32b-989934a51846",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.268145904755,
-          46.419243380608
-        ]
-      },
-      "properties": {
-        "uic": 8501031,
-        "didokId": "01031",
-        "operator": "SBB",
-        "displayName": "Gland",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Route de Nyon 1",
-          "city": "Gland",
-          "postalCode": "1196"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "271"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 164
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 5
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "4ceebf82-b71d-4f28-b3d9-fab6894c53c1",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.235816599614,
-          47.373008259635
+          8.235806917704668,
+          47.37299804750855
         ]
       },
       "properties": {
@@ -30730,94 +33952,12 @@
     },
     {
       "type": "Feature",
-      "id": "4cf972cf-6ad2-46db-b071-ddba61e9e751",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.915311573086,
-          47.313492936194
-        ]
-      },
-      "properties": {
-        "uic": 8503137,
-        "didokId": "03137",
-        "operator": "SBB",
-        "displayName": "Gibswil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Tösstalstrasse 465",
-          "city": "Gibswil",
-          "postalCode": "8498"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "460"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 11
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a1378360-66d5-4914-add4-abcbbf4aee3e",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.468199,
-          47.473733
+          9.468359824866187,
+          47.473755663701716
         ]
       },
       "properties": {
@@ -30899,99 +34039,12 @@
     },
     {
       "type": "Feature",
-      "id": "48ac2871-3b19-44bc-9da6-6f13bc5fb8e4",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.52979092735274,
-          46.855048215485986
-        ]
-      },
-      "properties": {
-        "uic": 8509000,
-        "didokId": "09000",
-        "operator": "SBB",
-        "displayName": "Chur",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Gürtelstrasse 48",
-          "city": "Chur",
-          "postalCode": "7000"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1200,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 200
-            }
-          ],
-          "monthlyTicketPrice": 12000,
-          "yearlyTicketPrice": 120000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "463"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 119
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Belagsarbeiten der Stadt ist mit Verkehrsbehinderungen auf der Gürtelstrasse zu rechnen. Planen Sie genügend Reisezeit ein.\nEinfahrt Parkhaus: Gürtelstrasse 48.",
-          "en": "Traffic obstructions are to be expected on the Gürtelstrasse due to resurfacing work being carried out by the city. Allow sufficient travelling time.\nEntrance to the car park: Gürtelstrasse 48.",
-          "it": "Si prevedono intralci al traffico sulla Gürtelstrasse a causa dei lavori di ripavimentazione effettuati dalla città. Prevedere un tempo di percorrenza sufficiente.\nEntrata autosilo: Gürtelstrasse 48.",
-          "fr": "En raison de travaux de revêtement effectués par la ville, il faut s'attendre à des perturbations du trafic sur la Gürtelstrasse. Prévoyez suffisamment de temps de trajet.\nEntrée parking souterrain: Gürtelstrasse 48."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "75cccdc0-75db-4dac-b436-53289b232450",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.50637294107,
-          46.933933900367
+          7.5072257809595015,
+          46.93341588189812
         ]
       },
       "properties": {
@@ -31057,10 +34110,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
+          "de": "Eingeschränktes Parkplatzangebot bis 2029\nDie Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
+          "en": "Limited number of car parking spaces until 2029.\nThe parking meter is retired. But the P+Rail app can do much more.",
+          "it": "Numero limitato di posti auto fino al 2029.\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "fr": "Offre limitée de places de stationnement jusqu'en 2029.\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -31077,8 +34130,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.726438730049874,
-          47.48852568886857
+          7.726882963072345,
+          47.488608750303094
         ]
       },
       "properties": {
@@ -31164,8 +34217,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.72259458525,
-          47.409397466867
+          8.722703009897996,
+          47.409245330093384
         ]
       },
       "properties": {
@@ -31246,8 +34299,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.354852050996,
-          47.433012532413
+          8.355163581557047,
+          47.433205443952914
         ]
       },
       "properties": {
@@ -31328,8 +34381,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.023268,
-          47.217606
+          9.023321927662911,
+          47.21755704317751
         ]
       },
       "properties": {
@@ -31415,8 +34468,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.252407933135,
-          47.222584243176
+          8.252443975253145,
+          47.222520351135564
         ]
       },
       "properties": {
@@ -31502,8 +34555,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.844553872214,
-          47.330589974202
+          7.844647333297754,
+          47.330556356611964
         ]
       },
       "properties": {
@@ -31585,99 +34638,12 @@
     },
     {
       "type": "Feature",
-      "id": "4225c609-235d-47a1-af53-4b1fc47af458",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.013757706152,
-          47.507998135072
-        ]
-      },
-      "properties": {
-        "uic": 8500305,
-        "didokId": "00305",
-        "operator": "SBB",
-        "displayName": "Frick",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 1",
-          "city": "Frick",
-          "postalCode": "5070"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "395"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 139
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 5
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Mit einer Monats- oder Jahresparkkarte P+R Frick kann wie folgt parkiert werden: \r\n- Parkhaus Bahnhof (Tageskarte CHF 8.00, an der Parkkasse zu bezahlen)\r\n- SBB P+R-Anlage (Stunden- und Tageskarte auch in der P+Rail-App buchbar: \"Frick\"\r\n- Parkplatz Blaie (Blaienweg, gegenüber Tierarztpraxis, ca 5 Minuten Fussweg / Stunden- und Tageskarten auch in der P+Rail-App buchbar: \"Frick (P+Rail Blaieweg)\"  \r\n\r\n",
-          "en": "With a monthly or annual parking card P+R Frick can be parked as follows: \r\n- Parking at Railwaystation (day pass CHF 8.00, to be paid at the parking cash desk)  \r\n- SBB P+R facility  \r\n- Blaien car park (Blaienweg, opposite the veterinary practice, approx. 5 minutes walk / day tickets not valid!)  ",
-          "it": "Con una tessera di parcheggio mensile o annuale, nel P+R di Frick può essere parcheggiato come segue:\r\n- FFS Parcheggio alla stazione (biglietti giornalieri CHF 8.00, da pagare alla cassa del parcheggio) \r\n- Impianto P+R delle FFS \r\n- Parcheggio Blaien (Blaienweg, di fronte allo studio veterinario, ca. 5 minuti a piedi / biglietti giornalieri non validi!)  \r\n \r\n",
-          "fr": "Avec une carte de stationnement mensuelle ou annuelle, il est possible de se parquer comme suit auprès de P+R Frick: \r\n- Parking de la gare (billets journaliers CHF 8.00, à payer à la caisse du parking)\r\n- Le dispositif P+R du CFF  \r\n- Parking Blaie (Blaienweg, en face du cabinet vétérinaire, environ 5 à pied / billets journaliers non valables !)  \r\n"
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "f479c6ba-4957-4ea2-aa57-7200f9dc7900",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.613907973819,
-          47.280956645838
+          8.613799078811489,
+          47.28096958230932
         ]
       },
       "properties": {
@@ -31754,99 +34720,12 @@
     },
     {
       "type": "Feature",
-      "id": "7999711b-3621-4730-814f-1da385ca2d17",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.466588886439,
-          47.220168493555
-        ]
-      },
-      "properties": {
-        "uic": 8502226,
-        "didokId": "02226",
-        "operator": "SBB",
-        "displayName": "Knonau",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Chamstrasse 31",
-          "city": "Knonau",
-          "postalCode": "8934"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "325"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 91
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "2422c0f0-3998-4422-9a90-6b6f8a68f583",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.626774013422,
-          47.410178794969
+          9.626798305137628,
+          47.409969890299735
         ]
       },
       "properties": {
@@ -31927,8 +34806,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.446258527647,
-          47.29882041404
+          8.4456803873682,
+          47.299249146276544
         ]
       },
       "properties": {
@@ -32009,8 +34888,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.592632105627,
-          47.441414035665
+          7.592642545939511,
+          47.44141547540515
         ]
       },
       "properties": {
@@ -32092,99 +34971,12 @@
     },
     {
       "type": "Feature",
-      "id": "1fb345a3-8605-49b8-931a-58da17e792c9",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.287863778504,
-          47.167944688463
-        ]
-      },
-      "properties": {
-        "uic": 8502024,
-        "didokId": "02024",
-        "operator": "SBB",
-        "displayName": "Hochdorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 2",
-          "city": "Hochdorf",
-          "postalCode": "6280"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "213"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 28
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "56baed79-665f-4b0a-9061-1ab7c8962735",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.591039,
-          47.306231
+          8.591051518875403,
+          47.306427656219604
         ]
       },
       "properties": {
@@ -32265,8 +35057,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.790515700069,
-          46.483249568648
+          8.790338935080637,
+          46.48331573678655
         ]
       },
       "properties": {
@@ -32343,99 +35135,12 @@
     },
     {
       "type": "Feature",
-      "id": "e7144927-9450-4d2d-81cc-652d3e98c406",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.83944670734,
-          47.300454422831
-        ]
-      },
-      "properties": {
-        "uic": 8503130,
-        "didokId": "03130",
-        "operator": "SBB",
-        "displayName": "Hinwil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 3",
-          "city": "Hinwil",
-          "postalCode": "8340"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "345"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 48
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more.  ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "97433a48-0376-4e1c-9eca-98ab8d63cadb",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.593241751552121,
-          47.2623199
+          8.593338160384656,
+          47.262348048057405
         ]
       },
       "properties": {
@@ -32521,8 +35226,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.251878934393,
-          47.476869106922
+          9.251527728659605,
+          47.47706802190901
         ]
       },
       "properties": {
@@ -32608,8 +35313,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.924702595037,
-          46.124415464112
+          8.924840918365199,
+          46.12423356303008
         ]
       },
       "properties": {
@@ -32699,8 +35404,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.065072,
-          46.83189
+          7.064812273244151,
+          46.83177123875248
         ]
       },
       "properties": {
@@ -32781,8 +35486,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.66245602632,
-          46.899368579586
+          7.662349444336759,
+          46.899207507759435
         ]
       },
       "properties": {
@@ -32868,8 +35573,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.640531449270827,
-          46.78240743258861
+          6.638933074469521,
+          46.782675036456105
         ]
       },
       "properties": {
@@ -32950,8 +35655,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          5.999109610906,
-          46.17858988451
+          5.998807336641649,
+          46.17858013624193
         ]
       },
       "properties": {
@@ -33037,8 +35742,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.760778105557,
-          47.470135574494
+          7.760968512306876,
+          47.47010419218522
         ]
       },
       "properties": {
@@ -33124,8 +35829,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.207788757147,
-          47.388869882481
+          8.207413492110843,
+          47.389161718515815
         ]
       },
       "properties": {
@@ -33211,15 +35916,15 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.257392395037,
-          47.05326249085
+          8.257342572280546,
+          47.05321159691067
         ]
       },
       "properties": {
         "uic": 8508219,
         "didokId": "08219",
         "operator": "SBB",
-        "displayName": "Littau",
+        "displayName": "Littau (Luzern)",
         "publicAccess": true,
         "address": {
           "addressLine": "Cheerstrasse 16",
@@ -33298,8 +36003,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.72319269259,
-          47.538172471078
+          7.723788846266393,
+          47.5382908665391
         ]
       },
       "properties": {
@@ -33385,8 +36090,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.061485,
-          47.58321
+          9.061317338971245,
+          47.583240333241406
         ]
       },
       "properties": {
@@ -33468,99 +36173,12 @@
     },
     {
       "type": "Feature",
-      "id": "38917b27-2352-405b-a144-851645281ccc",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.18624,
-          46.72696
-        ]
-      },
-      "properties": {
-        "uic": 8508308,
-        "didokId": "08308",
-        "operator": "zb",
-        "displayName": "Meiringen Kiesplatz (zb - Die Zentralbahn)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 12",
-          "city": "Meiringen",
-          "postalCode": "3860 "
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "1063"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 13
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Nur Stunden- und Tagestickets, es werden keine Abos verkauft.\n",
-          "en": "Only hourly and day tickets, no subscriptions are sold.\n",
-          "it": "Si vendono solo biglietti orari e giornalieri, non abbonamenti.\n",
-          "fr": "Billets horaires et journaliers uniquement, aucun abonnement n'est vendu.\n"
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "8588d633-e858-4a33-b44b-4d13b3437e70",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.009313,
-          47.204067
+          9.009384822106613,
+          47.20398293464739
         ]
       },
       "properties": {
@@ -33902,8 +36520,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.640556162566,
-          46.80590092712
+          6.639993215081796,
+          46.805722393800615
         ]
       },
       "properties": {
@@ -33984,8 +36602,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.678633,
-          46.512987
+          6.6785020884476936,
+          46.51299919597726
         ]
       },
       "properties": {
@@ -34245,8 +36863,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.723420085914,
-          46.497147683632
+          6.723595029903159,
+          46.49713667932985
         ]
       },
       "properties": {
@@ -34327,8 +36945,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.766523,
-          47.487758
+          8.766415035559364,
+          47.48791803244213
         ]
       },
       "properties": {
@@ -34409,8 +37027,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.43275,
-          47.082766
+          8.432311411911508,
+          47.082183432340145
         ]
       },
       "properties": {
@@ -34475,12 +37093,7 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund von Bauarbeiten beschränktes Platzangebot vom 11.03. - Mitte August 2024.",
-          "en": "Limited space available from 11 March to mid-August 2024 due to construction work.",
-          "it": "Spazio limitato disponibile dall'11 marzo a metà agosto 2024 a causa di lavori di costruzione.",
-          "fr": "En raison de travaux, offre de places limitée du 11 mars à la mi-août 2024."
-        },
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -34496,8 +37109,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.401267763824,
-          47.189564517608
+          7.401191910189152,
+          47.18952103798758
         ]
       },
       "properties": {
@@ -34551,7 +37164,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
+            "total": 3
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -34579,99 +37192,12 @@
     },
     {
       "type": "Feature",
-      "id": "45b3ae1c-91f5-4a75-a856-2289bed7f9c7",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.653624890282,
-          47.634819006846
-        ]
-      },
-      "properties": {
-        "uic": 8506048,
-        "didokId": "06048",
-        "operator": "SBB",
-        "displayName": "Marthalen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Ruedelfingerstrass 1",
-          "city": "Marthalen",
-          "postalCode": "8460"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "133"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 117
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "74eedaf8-126f-4fce-94e0-505d5744b270",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.383388744844,
-          47.050357723528
+          8.38340548497201,
+          47.0503472421127
         ]
       },
       "properties": {
@@ -34741,93 +37267,6 @@
           "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
           "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "b1cd88ad-3cf5-4572-b1bf-41712eda4739",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.554149398078,
-          46.968462189414
-        ]
-      },
-      "properties": {
-        "uic": 8509002,
-        "didokId": "09002",
-        "operator": "SBB",
-        "displayName": "Landquart (SBB)",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 1",
-          "city": "Landquart",
-          "postalCode": "7302"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "60"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 80
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund eines Umbaus können zurzeit keine Jahresparkkarten gekauft werden.  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "Due to a renovation, annual parking cards cannot be purchased at the moment.  This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "A causa di una ristrutturazione, al momento non è possibile acquistare tessere di parcheggio annuali.  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "En raison d'une transformation, il n'est actuellement pas possible d'acheter des cartes de stationnement annuelles.  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -34931,8 +37370,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.209768,
-          47.33492
+          7.210001898446793,
+          47.334895366871635
         ]
       },
       "properties": {
@@ -35014,99 +37453,12 @@
     },
     {
       "type": "Feature",
-      "id": "a459aa1d-11c1-444d-b870-8b097d90372b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.080936,
-          47.009907
-        ]
-      },
-      "properties": {
-        "uic": 8503232,
-        "didokId": "03232",
-        "operator": "SBB",
-        "displayName": "Mitlödi",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 4",
-          "city": "Glarus-Süd / Mitlödi",
-          "postalCode": "8756"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "566"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 10
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3bd86241-5b95-4e49-bc0b-492b8bfd6a48",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.580076558475,
-          47.320299732547
+          8.580022645442515,
+          47.32033988801857
         ]
       },
       "properties": {
@@ -35192,8 +37544,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.744446,
-          47.05704
+          6.7443549824929985,
+          47.05704578919123
         ]
       },
       "properties": {
@@ -35275,94 +37627,12 @@
     },
     {
       "type": "Feature",
-      "id": "1f5a5d4a-f97d-4d9d-9391-5c43c503e379",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.957710130688,
-          47.461596042704
-        ]
-      },
-      "properties": {
-        "uic": 8506011,
-        "didokId": "06011",
-        "operator": "SBB",
-        "displayName": "Eschlikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 1",
-          "city": "Eschlikon",
-          "postalCode": "8360"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "117"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 80
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "15eeb176-1c1f-4a09-9525-2cbd421e90fe",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.523748317197,
-          46.605346391929
+          6.52376690400197,
+          46.60540404950771
         ]
       },
       "properties": {
@@ -35443,8 +37713,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.783135835513,
-          47.23892494087
+          8.782765432539142,
+          47.238814559002265
         ]
       },
       "properties": {
@@ -35530,8 +37800,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.5867247,
-          47.3926654
+          9.58736891871284,
+          47.39298095059861
         ]
       },
       "properties": {
@@ -35617,8 +37887,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.617919631947,
-          47.513667231374
+          7.618015402116191,
+          47.51375934410493
         ]
       },
       "properties": {
@@ -35704,8 +37974,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.305455408737,
-          47.077723572246
+          7.30535003024857,
+          47.077947696427806
         ]
       },
       "properties": {
@@ -35786,8 +38056,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.802809682873,
-          46.668436900055
+          6.8029755557726155,
+          46.6685367288134
         ]
       },
       "properties": {
@@ -35869,99 +38139,12 @@
     },
     {
       "type": "Feature",
-      "id": "bc024fdc-b367-4aa7-a3f8-11def2338dfb",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.951026884023,
-          45.95445385426
-        ]
-      },
-      "properties": {
-        "uic": 8505302,
-        "didokId": "05302",
-        "operator": "SBB",
-        "displayName": "Melide",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Via Cantonale 29",
-          "city": "Melide",
-          "postalCode": "6815"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "92"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 55
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund einer Baustelle gibt es nur ein eingeschränktes Angebot an Abos. Aufgrund von Bauarbeiten stehen ab 01.03.2023 - Ende 2024 eine begrenzten Anzahl an Parkplätzen zur Verfügung.",
-          "en": "Due to a construction site, there is only a limited number of subscriptions available. Due to construction work, a limited number of parking spaces will be available from 01.03.2023 - end of 2024.",
-          "it": "A causa di un cantiere, c'è solo una disponibilità limitata di abbonamenti.\r\nI lavori di costruzione causeranno alcuni disagi agli utenti della stazione. Per far spazio alle installazioni di cantiere parte del P+Rail non sarà agibile fino al termine dei lavori, a fine 2024.",
-          "fr": "En raison d'un chantier, il n'y a qu'une offre limitée d'abonnements. En raison de travaux, un nombre limité de places de parking sera disponible à partir du 01.03.2023 -fin 2024."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "94a72266-e912-4271-bbd7-8354f666717d",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.05954268948,
-          47.558905299812
+          8.059314115982833,
+          47.558794791770545
         ]
       },
       "properties": {
@@ -36047,8 +38230,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.983477962952,
-          47.172394654445
+          8.983350274351936,
+          47.17239462670239
         ]
       },
       "properties": {
@@ -36134,8 +38317,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.801903383081,
-          46.306121092315
+          7.801768444215522,
+          46.306095233074856
         ]
       },
       "properties": {
@@ -36221,8 +38404,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.93064478102,
-          46.057308299943
+          8.930380229293215,
+          46.05759063601198
         ]
       },
       "properties": {
@@ -36287,12 +38470,7 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": {
-          "de": ".",
-          "en": ".",
-          "it": ".",
-          "fr": "."
-        },
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -36308,8 +38486,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.571336768717,
-          47.323752959851
+          9.571312240854168,
+          47.32386165741721
         ]
       },
       "properties": {
@@ -36391,181 +38569,12 @@
     },
     {
       "type": "Feature",
-      "id": "2797c219-6441-408b-b02d-c21dece4ce41",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.227314522754,
-          47.633350393917
-        ]
-      },
-      "properties": {
-        "uic": 8506126,
-        "didokId": "06126",
-        "operator": "SBB",
-        "displayName": "Münsterlingen-Scherzingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Seestrasse 30",
-          "city": "Münsterlingen",
-          "postalCode": "8596"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "348"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 6
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "86accb98-fcf9-4c6f-b5f2-c54ec7b87e01",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.624985846033,
-          47.682519668709
-        ]
-      },
-      "properties": {
-        "uic": 8503423,
-        "didokId": "03423",
-        "operator": "SBB",
-        "displayName": "Neuhausen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 27",
-          "city": "Neuhausen",
-          "postalCode": "8212"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "410"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 66
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "e6691123-d701-4ba4-a970-a4de03f3be5b",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.190211,
-          47.625969
+          9.190518836044903,
+          47.62566164436988
         ]
       },
       "properties": {
@@ -36616,88 +38625,6 @@
           {
             "categoryType": "STANDARD",
             "total": 19
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "2f8db5e1-3096-4e49-abe2-a11c36b4e3de",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.026167509262,
-          47.336131474405
-        ]
-      },
-      "properties": {
-        "uic": 8502101,
-        "didokId": "02101",
-        "operator": "SBB",
-        "displayName": "Kölliken",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 6",
-          "city": "Kölliken",
-          "postalCode": "5742"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "435"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 7
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -36989,8 +38916,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.064825,
-          46.765945
+          7.065205856530621,
+          46.76646878769813
         ]
       },
       "properties": {
@@ -37159,355 +39086,12 @@
     },
     {
       "type": "Feature",
-      "id": "41972fee-3337-4bcb-a264-de759dbbfdec",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.589637494512,
-          46.668045034218
-        ]
-      },
-      "properties": {
-        "uic": 8505119,
-        "didokId": "05119",
-        "operator": "SBB",
-        "displayName": "Göschenen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Gotthardstrasse 16",
-          "city": "Göschenen",
-          "postalCode": "6487"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "07:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "69"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 48
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "c0b66636-73ee-482b-8fb8-e658001cf855",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.226592944775,
-          47.599674921591
-        ]
-      },
-      "properties": {
-        "uic": 8500329,
-        "didokId": "00329",
-        "operator": "SBB",
-        "displayName": "Koblenz",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 55",
-          "city": "Koblenz",
-          "postalCode": "5322"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "157"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 113
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "d716520e-efc3-4a9a-b14d-5cd2e0116c12",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.080051155554177,
-          46.105678438420824
-        ]
-      },
-      "properties": {
-        "uic": 8501500,
-        "didokId": "01500",
-        "operator": "SBB",
-        "displayName": "Martigny",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rue de Bellevue 5",
-          "city": "Martigny",
-          "postalCode": "1920"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "969"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 36
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Aufgrund der Bauarbeiten sind die P+Rail Parkplätze von Montag, 27. Februar 2023 bis Mittwoch, 28. Juni 2023 ausser Betrieb. Während dieser Zeit wird ein provisorischer, gebührenpflichtiger Parkplatz am Rande der Rue des Prés Magnin eingerichtet und den Kunden zur Verfügung gestellt.  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. .\r\nDie obigen Angaben beziehen sich ausschliesslich auf die P+Rail Tageskarten.\r\nMonats- und Jahresabonnemente sind bei der Stadtpolizei Martigny zu lösen: 50.–/Monat, 550.–/Jahr für den Parkplatz Les Neuvilles (7 Min. zu Fuss vom Bahnhof) und 100.–/Monat, 1100.–/Jahr für den Parkplatz am Busbahnhof. Diese Abos sind ohne Bahnabo erhältlich.",
-          "en": "Due to the construction work, the P+Rail car parks will be out of service from Monday 27 February 2023 to Wednesday 28 June 2023. During this time, a temporary, pay-and-display car park will be set up on the edge of Rue des Prés Magnin and made available to customers.  This parking cash register has retired. But its successor, the P+R App, can do much more. .\r\nDie obigen Angaben beziehen sich ausschliesslich auf die P+Rail Tageskarten.\r\nMonthly and annual passes sold by the Martigny municipal police. CHF 50 per month/CHF 550 per year for the Neuvilles car park (a 7-minute walk from the station) and CHF 100 per month, CHF 1100 per year for the Gare routière car park. You do not need a travelcard to purchase one of these passes.",
-          "it": "A causa dei lavori di costruzione, i parcheggi P+Rail saranno fuori servizio da lunedì 27 febbraio 2023 a mercoledì 28 giugno 2023. Durante questo periodo, ai margini di Rue des Prés Magnin sarà allestito un parcheggio temporaneo a pagamento a disposizione dei clienti.  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. .\r\nLe informazioni di cui sopra si riferiscono esclusivamente ai biglietti giornalieri P+Rail.\r\nAbbonamenti mensili e annuali in vendita presso la polizia municipale di Martigny: 50.–/mese, 550.– all’anno per il parcheggio di Neuvilles (7 min a piedi dalla stazione) e 100.–/mese, 1100.– all’anno per il parcheggio Gare routière. Questi abbonamenti possono essere ottenuti anche senza abbonamento ferroviario.",
-          "fr": "En raison des travaux, les parkings P+Rail seront hors service du lundi 27 février 2023 au mercredi 28 juin 2023. Pendant cette période, un parking provisoire payant sera aménagé en bordure de la rue des Prés Magnin et mis à la disposition des clients.  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. .\r\nLes informations ci-dessus se rapportent exclusivement aux cartes journalières P+Rail.\r\nAbonnements mensuels et annuels en vente à la Police municipale de Martigny : 50.–/mois, 550.– année pour le parking des Neuvilles (7 min à pieds de la gare) et 100.–/mois, 1100.– année pour le parking Gare routière. Ces abonnements peuvent être obtenus sans abonnement de train."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "2b713d4f-6f4a-4ef7-894a-30280881e4f6",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.453232540931,
-          47.021177624887
-        ]
-      },
-      "properties": {
-        "uic": 8504411,
-        "didokId": "04411",
-        "operator": "SBB",
-        "displayName": "Münchenbuchsee",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Dammweg 1",
-          "city": "Münchenbuchsee",
-          "postalCode": "3053"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 200
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "47"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 87
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "dd4155f4-d974-4b9d-afc7-f2fc68b9a4f9",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.940882117266,
-          46.820630134894
+          6.94088868405757,
+          46.82069257586208
         ]
       },
       "properties": {
@@ -37557,7 +39141,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 95
+            "total": 96
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -37593,8 +39177,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.516066,
-          47.572933
+          8.51569395588359,
+          47.57287329582921
         ]
       },
       "properties": {
@@ -37674,8 +39258,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.532154858197,
-          47.454304957075
+          8.532246779006671,
+          47.45413902106405
         ]
       },
       "properties": {
@@ -37756,8 +39340,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.014206766201,
-          46.949818098433
+          8.014019990097506,
+          46.94969050256152
         ]
       },
       "properties": {
@@ -37843,8 +39427,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.197827860713,
-          47.115985058149
+          8.197552785330762,
+          47.11598756796258
         ]
       },
       "properties": {
@@ -37930,8 +39514,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.591158,
-          47.46652
+          9.591587468333644,
+          47.465977520560884
         ]
       },
       "properties": {
@@ -38012,8 +39596,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.878435825131,
-          47.306067350503
+          7.878310924021575,
+          47.306031965100466
         ]
       },
       "properties": {
@@ -38094,8 +39678,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.770947337365,
-          47.304976902811
+          7.770894749697449,
+          47.30497833673069
         ]
       },
       "properties": {
@@ -38177,94 +39761,12 @@
     },
     {
       "type": "Feature",
-      "id": "fb7a54c1-c5ff-49a2-8bcb-f1008c3088bf",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.968128193324,
-          47.241948682016
-        ]
-      },
-      "properties": {
-        "uic": 8502003,
-        "didokId": "02003",
-        "operator": "SBB",
-        "displayName": "Reiden",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Werkstrasse 5",
-          "city": "Reiden",
-          "postalCode": "6260"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "203"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 32
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "3169ce8b-72c3-487c-b2c4-46832e27c003",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.647366731213,
-          47.533662491103
+          7.647336615339001,
+          47.53359095955341
         ]
       },
       "properties": {
@@ -38279,9 +39781,9 @@
           "postalCode": "4132"
         },
         "pricingModel": {
-          "minimumDuration": 60,
+          "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 500,
+          "maximumDayPrice": 1000,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -38341,186 +39843,12 @@
     },
     {
       "type": "Feature",
-      "id": "63456cd8-5cc0-4bb5-b050-aaa570157914",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.610818765082,
-          47.490837395665
-        ]
-      },
-      "properties": {
-        "uic": 8500118,
-        "didokId": "00118",
-        "operator": "SBB",
-        "displayName": "Dornach-Arlesheim",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 8",
-          "city": "Dornach-Arlesheim",
-          "postalCode": "4144"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 800,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 200
-            }
-          ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "241"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 45
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "12 oberirdische Parkplätze und 33 Parkplätze in der Tiefgarage.\r\nDie Parkuhr geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
-          "en": "12 overground parking spaces and 33 underground parking spaces.\r\nThe parking meter is retired. But the P+Rail app can do much more.",
-          "it": "12 posti all'aperto, 33 posti sotterranei.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
-          "fr": "12 places en surface et 33 places en souterrain.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "386bdae2-5e73-41ad-9e6f-d4f7978197ea",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          6.903764612967,
-          46.984138816321
-        ]
-      },
-      "properties": {
-        "uic": 8504220,
-        "didokId": "04220",
-        "operator": "SBB",
-        "displayName": "Neuchâtel-Serrières",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Rue des Amandiers 6",
-          "city": "Neuchâtel-Serrières",
-          "postalCode": "2000"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "186"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 22
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "c742c4ce-bacf-43be-9bc5-fb8547f2a3f7",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.575728381545,
-          46.818530797375
+          7.575735455696062,
+          46.81856134260103
         ]
       },
       "properties": {
@@ -38605,8 +39933,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.143986606082,
-          47.037855546746
+          8.144023268543906,
+          47.03784821604149
         ]
       },
       "properties": {
@@ -38692,8 +40020,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.788509272491,
-          47.535298424013
+          8.78964569361515,
+          47.53551146007607
         ]
       },
       "properties": {
@@ -38775,99 +40103,12 @@
     },
     {
       "type": "Feature",
-      "id": "d339ce85-1731-4d9f-bd35-b663a95976ae",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.794955349529,
-          47.445618532492
-        ]
-      },
-      "properties": {
-        "uic": 8506005,
-        "didokId": "06005",
-        "operator": "SBB",
-        "displayName": "Rikon",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Tösstalstrasse 49",
-          "city": "Rikon (Zell)",
-          "postalCode": "8486"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "377"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 11
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "917555f7-1eb0-443e-9d8f-1e55a0737c18",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.819504841,
-          47.441212746346
+          8.819208804138581,
+          47.44131785823485
         ]
       },
       "properties": {
@@ -38953,8 +40194,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.910307270045,
-          47.547418491588
+          7.910031085873604,
+          47.54753144752131
         ]
       },
       "properties": {
@@ -39040,8 +40281,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.938480590738,
-          47.176322996387
+          8.93768166210418,
+          47.17624622705845
         ]
       },
       "properties": {
@@ -39127,8 +40368,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.411622960713,
-          47.498148325532
+          8.411507308562708,
+          47.49811307543657
         ]
       },
       "properties": {
@@ -39209,8 +40450,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.658873617405,
-          47.384679994474
+          8.658325497115008,
+          47.38482470442451
         ]
       },
       "properties": {
@@ -39291,8 +40532,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.999915128172,
-          47.370801811174
+          7.99989893546314,
+          47.37078673309948
         ]
       },
       "properties": {
@@ -39342,7 +40583,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 16
+            "total": 28
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -39378,8 +40619,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.075005087102,
-          47.360064142021
+          9.07494119067648,
+          47.36041322649069
         ]
       },
       "properties": {
@@ -39461,94 +40702,12 @@
     },
     {
       "type": "Feature",
-      "id": "82881566-f59e-415f-9042-321a01eea205",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.739359160783,
-          47.535418359178
-        ]
-      },
-      "properties": {
-        "uic": 8506020,
-        "didokId": "06020",
-        "operator": "SBB",
-        "displayName": "Seuzach",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Stationsstrasse 58",
-          "city": "Seuzach",
-          "postalCode": "8472"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "382"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 73
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "21527d51-0b18-44c4-8ebf-54109ed2ab6c",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.500347,
-          47.4778158
+          9.502453041982415,
+          47.477737682083976
         ]
       },
       "properties": {
@@ -39630,106 +40789,12 @@
     },
     {
       "type": "Feature",
-      "id": "8bf5f03e-3513-43db-a448-f41cb43a35f4",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.819162286578,
-          47.225392288824
-        ]
-      },
-      "properties": {
-        "uic": 8503110,
-        "didokId": "03110",
-        "operator": "SBB",
-        "displayName": "Rapperswil SBB P+Rail",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 777",
-          "city": "Rapperswil",
-          "postalCode": "8640"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            },
-            {
-              "startingFrom": 60,
-              "price": 150
-            },
-            {
-              "startingFrom": 120,
-              "price": 250
-            }
-          ],
-          "monthlyTicketPrice": 10000,
-          "yearlyTicketPrice": 100000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "333"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 178
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 2
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": {
-          "eChargingStationOperatorID": "30bd1b8b-b1a6-4957-9d02-eb607c1f9ec2",
-          "eChargingStationOperatorName": "swisscharge",
-          "eChargingStationOperatorLink": "https://map.swisscharge.ch/"
-        }
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1b5bd747-b55c-453a-9724-2e9a9e10579b",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.969292,
-          46.158341
+          8.969426215177583,
+          46.1582700231903
         ]
       },
       "properties": {
@@ -39810,8 +40875,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.530364021673,
-          46.291434015883
+          7.530165423729786,
+          46.29130322668673
         ]
       },
       "properties": {
@@ -39897,8 +40962,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.0023755,
-          46.2154634
+          7.002248501737143,
+          46.21559177611462
         ]
       },
       "properties": {
@@ -39915,7 +40980,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 600,
+          "maximumDayPrice": 800,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -39980,99 +41045,12 @@
     },
     {
       "type": "Feature",
-      "id": "def41dab-a462-45f4-a3dd-ee5985fc0a55",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.273365729639,
-          47.091108126443
-        ]
-      },
-      "properties": {
-        "uic": 8502012,
-        "didokId": "02012",
-        "operator": "SBB",
-        "displayName": "Emmenbrücke Kapf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bachtalenstrasse 4",
-          "city": "Rothenburg Dorf (Kapf)",
-          "postalCode": "6020"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "208"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 5
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Keine Parkplätze vorhanden.",
-          "en": "No parking available",
-          "it": "Nessun parcheggio disponibile",
-          "fr": "Pas de places de parc disponibles."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a0281196-d489-4784-b45b-d3143719e116",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.577138076652,
-          47.277284718435
+          8.577047474899418,
+          47.277323759877305
         ]
       },
       "properties": {
@@ -40153,8 +41131,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.169354,
-          47.572318
+          9.170185632934208,
+          47.5724017813689
         ]
       },
       "properties": {
@@ -40231,181 +41209,12 @@
     },
     {
       "type": "Feature",
-      "id": "a1e6df62-2673-4773-9e3e-cdaca572572d",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.256557179439906,
-          47.57485062701451
-        ]
-      },
-      "properties": {
-        "uic": 8503501,
-        "didokId": "03501",
-        "operator": "SBB",
-        "displayName": "Döttingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofplatz 2",
-          "city": "Döttingen",
-          "postalCode": "5312"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "277"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 128
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "An der Parkuhr kann nur mit Kreditkarte bezahlt werden. Keine Bezahlung mit Bargeld möglich",
-          "en": "Payment at the car parking counter is only possible by credit card.",
-          "it": "Il pagamento al parchimetro è possibile solo con carta di credito.",
-          "fr": "Le paiement au parcmètre n'est possible que par carte de crédit."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "10299d2e-73e8-4ed5-8f2f-7924e23dd2cd",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.481715695245,
-          46.955244959846
-        ]
-      },
-      "properties": {
-        "uic": 8507002,
-        "didokId": "07002",
-        "operator": "SBB",
-        "displayName": "Ostermundigen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bernstrasse 24",
-          "city": "Ostermundigen",
-          "postalCode": "3072"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "54"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 42
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 2
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "7810a280-1369-48de-af7d-82eef1a0cb61",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.131036995107,
-          47.436814638033
+          9.131100074657807,
+          47.43708030044477
         ]
       },
       "properties": {
@@ -40491,8 +41300,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.002056456761,
-          47.46239242094
+          9.002042086880742,
+          47.462465394256846
         ]
       },
       "properties": {
@@ -40578,8 +41387,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.130443172105,
-          47.659864038071
+          9.130545294604948,
+          47.65986821825864
         ]
       },
       "properties": {
@@ -40665,8 +41474,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.340534606013,
-          47.585620780294
+          9.34045787832563,
+          47.585608393979086
         ]
       },
       "properties": {
@@ -40752,8 +41561,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.699677,
-          46.309211
+          7.699469963677224,
+          46.30922651054027
         ]
       },
       "properties": {
@@ -40818,12 +41627,7 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
+        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -40839,8 +41643,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.984464361902,
-          47.321702129261
+          7.984826476284248,
+          47.32171647922929
         ]
       },
       "properties": {
@@ -40921,8 +41725,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.569687,
-          47.337759
+          8.569489169455284,
+          47.33794902855487
         ]
       },
       "properties": {
@@ -41003,8 +41807,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.91354250423,
-          47.272638084818
+          8.912624781273452,
+          47.27208928894208
         ]
       },
       "properties": {
@@ -41090,8 +41894,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.926790797623,
-          46.399285823376
+          6.926743350879152,
+          46.39927986678422
         ]
       },
       "properties": {
@@ -41177,8 +41981,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.314483149004,
-          47.460846840276
+          8.31467297572837,
+          47.460737268315455
         ]
       },
       "properties": {
@@ -41243,7 +42047,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten sind keine P+Rail Monats- und Jahresabonnemente verfügbar.",
+          "en": "Due to construction work, no P+Rail monthly and annual season tickets are available.\n\n",
+          "it": "A causa dei lavori di costruzione, non sono disponibili abbonamenti mensili e annuali P+Rail.\n",
+          "fr": "En raison de travaux, les abonnements mensuels et annuels P+Rail ne sont pas disponibles."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -41259,8 +42068,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.60865181059,
-          47.046698084367
+          8.60857209451585,
+          47.04671527067986
         ]
       },
       "properties": {
@@ -41346,8 +42155,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.814092718316,
-          47.462332122944
+          7.814756925003077,
+          47.46215043491739
         ]
       },
       "properties": {
@@ -41428,8 +42237,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.339099143586,
-          47.057864129053
+          7.33903945217074,
+          47.0580445203619
         ]
       },
       "properties": {
@@ -41515,8 +42324,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.544949525201,
-          47.204637308016
+          7.5459969463850705,
+          47.20477199130476
         ]
       },
       "properties": {
@@ -41606,8 +42415,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.631126,
-          46.754169
+          7.631610081063082,
+          46.75353300726016
         ]
       },
       "properties": {
@@ -41693,8 +42502,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.788873145438,
-          47.634341628872
+          8.788891827842496,
+          47.6343187948273
         ]
       },
       "properties": {
@@ -41780,8 +42589,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.037942,
-          46.138633
+          7.038087164245793,
+          46.13845201280846
         ]
       },
       "properties": {
@@ -41867,8 +42676,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.981331,
-          47.014376
+          6.982118816477333,
+          47.01472985874292
         ]
       },
       "properties": {
@@ -41949,8 +42758,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.062406,
-          46.782776
+          7.062773662104932,
+          46.78278664317938
         ]
       },
       "properties": {
@@ -42036,8 +42845,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.379366,
-          47.566847
+          9.379630214923104,
+          47.5670023260876
         ]
       },
       "properties": {
@@ -42123,8 +42932,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.75753937476,
-          47.569019142479
+          8.757481331082891,
+          47.56884025093061
         ]
       },
       "properties": {
@@ -42201,103 +43010,12 @@
     },
     {
       "type": "Feature",
-      "id": "e13d2788-80fa-4b81-addc-9a8ff3202503",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.950307,
-          47.541352
-        ]
-      },
-      "properties": {
-        "uic": 8500320,
-        "didokId": "00320",
-        "operator": "SBB",
-        "displayName": "Stein-Säckingen",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Altes Bahnhofgebäude",
-          "city": "Stein AG",
-          "postalCode": "4332"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 150
-            }
-          ],
-          "monthlyTicketPrice": 9000,
-          "yearlyTicketPrice": 90000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "155"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 244
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 4
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 4
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "4 E-Ladestation von Alfen vorhanden.  ",
-          "en": "4 e-charging stations from Alfen available.  ",
-          "it": "4 stazioni di ricarica elettronica disponibili presso Alfen.  \r\n ",
-          "fr": "4 stations de recharge électrique d'Alfen disponibles.  "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": {
-          "eChargingStationOperatorID": "de5d5816-ac74-4dfd-9a41-aa81421b0a87",
-          "eChargingStationOperatorName": "SBB",
-          "eChargingStationOperatorLink": "https://www.sbb.ch/"
-        }
-      }
-    },
-    {
-      "type": "Feature",
       "id": "1a27b190-bd92-4ca8-8509-d42a0ea3e989",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.299850363229,
-          47.403889224423
+          9.300397031490972,
+          47.40387473726149
         ]
       },
       "properties": {
@@ -42383,8 +43101,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.329585325795,
-          47.407270068873
+          9.329305697658992,
+          47.40726581726138
         ]
       },
       "properties": {
@@ -42465,8 +43183,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.074310953512,
-          47.18013495327
+          8.074281855768314,
+          47.18012405162308
         ]
       },
       "properties": {
@@ -42548,99 +43266,12 @@
     },
     {
       "type": "Feature",
-      "id": "0e81a485-c526-45c4-82ba-7875896a5418",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.619538567459,
-          47.060654420576
-        ]
-      },
-      "properties": {
-        "uic": 8508005,
-        "didokId": "08005",
-        "operator": "SBB",
-        "displayName": "Burgdorf",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bucherstrasse 2",
-          "city": "Burgdorf",
-          "postalCode": "3400"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1200,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "108"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 108
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Eingeschränktes Platzangebot",
-          "en": "Limited space available",
-          "it": "Spazio limitato disponibile",
-          "fr": "Espace réduit"
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "d8982db2-c6a2-4132-b266-fe28ea87a5a0",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.581009076721,
-          46.882099770562
+          7.580756631239469,
+          46.882434087988116
         ]
       },
       "properties": {
@@ -42726,8 +43357,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.544124505308,
-          47.418850800872
+          8.544027388187763,
+          47.41884780888379
         ]
       },
       "properties": {
@@ -42742,14 +43373,14 @@
           "postalCode": "8052"
         },
         "pricingModel": {
-          "minimumDuration": 60,
+          "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 500,
+          "maximumDayPrice": 1500,
           "viableIncrement": 60,
           "priceSegments": [
             {
               "startingFrom": 0,
-              "price": 100
+              "price": 200
             }
           ],
           "monthlyTicketPrice": 5000,
@@ -42808,8 +43439,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.676679620377,
-          46.942292602518
+          6.676722084641328,
+          46.94230878934839
         ]
       },
       "properties": {
@@ -42859,7 +43490,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 20
+            "total": 24
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -42890,8 +43521,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.165464441664,
-          46.280368166251
+          6.165444973861449,
+          46.28038015599371
         ]
       },
       "properties": {
@@ -42908,12 +43539,12 @@
         "pricingModel": {
           "minimumDuration": 240,
           "maximumDuration": 10080,
-          "maximumDayPrice": 700,
+          "maximumDayPrice": 1000,
           "viableIncrement": 60,
           "priceSegments": [
             {
               "startingFrom": 0,
-              "price": 100
+              "price": 150
             }
           ],
           "monthlyTicketPrice": 7000,
@@ -42977,8 +43608,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.715101194512,
-          47.352377760037
+          8.715238114974362,
+          47.35258567287222
         ]
       },
       "properties": {
@@ -43068,8 +43699,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.0996649,
-          47.169196
+          8.099936410775085,
+          47.16896195952486
         ]
       },
       "properties": {
@@ -43155,8 +43786,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.981742710906,
-          47.224165660604
+          8.982099718248463,
+          47.224016094938015
         ]
       },
       "properties": {
@@ -43237,8 +43868,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.319502112334,
-          47.107523659934
+          8.319517164808511,
+          47.10761846026155
         ]
       },
       "properties": {
@@ -43324,8 +43955,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.356851295701,
-          46.904189899922
+          7.356855983727001,
+          46.904197186789865
         ]
       },
       "properties": {
@@ -43406,8 +44037,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.582305863229,
-          46.795008790649
+          7.582110416750182,
+          46.79543487180413
         ]
       },
       "properties": {
@@ -43493,8 +44124,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.655695749004,
-          47.231663587232
+          7.655658847841134,
+          47.23161769396955
         ]
       },
       "properties": {
@@ -43575,8 +44206,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.888076,
-          47.445405
+          7.887667137569211,
+          47.4458514154002
         ]
       },
       "properties": {
@@ -43641,7 +44272,12 @@
             "total": 0
           }
         ],
-        "additionalInformationForCustomers": null,
+        "additionalInformationForCustomers": {
+          "de": "Aufgrund von Bauarbeiten wird ein Teil der P+Rail Parkplätze vom 03.07.2024 bis zum 12.08.2024 gesperrt sein.",
+          "en": "Due to construction work, part of the P+Rail car parks will be closed from 03.07.2024 to 12.08.2024.",
+          "it": "A causa di lavori di costruzione, una parte dei parcheggi P+Rail sarà chiusa dal 03.07.2024 al 12.08.2024.",
+          "fr": "En raison de travaux, une partie des parkings P+Rail sera fermée du 03/07/2024 au 12/08/2024."
+        },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -43657,8 +44293,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.001432603111,
-          47.151866213441
+          7.001178326036863,
+          47.15188414345765
         ]
       },
       "properties": {
@@ -43744,8 +44380,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.313780429361,
-          47.119858871485
+          9.31376964254469,
+          47.119843002665256
         ]
       },
       "properties": {
@@ -43831,8 +44467,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.397761995107,
-          47.187730651402
+          8.397646976494833,
+          47.18781593539478
         ]
       },
       "properties": {
@@ -43913,8 +44549,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.793171861902,
-          47.317644953648
+          8.793482737638612,
+          47.317262702528375
         ]
       },
       "properties": {
@@ -43995,8 +44631,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.36668,
-          47.422042
+          9.366819962213336,
+          47.42215685230564
         ]
       },
       "properties": {
@@ -44073,94 +44709,12 @@
     },
     {
       "type": "Feature",
-      "id": "5f503c5e-64e6-4482-865d-d871e3a99c66",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.548266843586,
-          47.324135827888
-        ]
-      },
-      "properties": {
-        "uic": 8503200,
-        "didokId": "03200",
-        "operator": "SBB",
-        "displayName": "Kilchberg",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 2",
-          "city": "Kilchberg",
-          "postalCode": "8802"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "159"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 0
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "293bde3b-8f54-4a8f-93b6-2f44cd513365",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.181371,
-          46.307712
+          6.1807014749506655,
+          46.3079854350357
         ]
       },
       "properties": {
@@ -44246,8 +44800,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.33965508102,
-          47.171453676247
+          7.3395734700472035,
+          47.171449087655034
         ]
       },
       "properties": {
@@ -44333,8 +44887,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.944544931213,
-          45.85017729949
+          8.944807177533887,
+          45.8501264461354
         ]
       },
       "properties": {
@@ -44388,7 +44942,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 0
+            "total": 2
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -44415,8 +44969,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.911394188222,
-          46.693029284268
+          6.910733052349213,
+          46.69268738676458
         ]
       },
       "properties": {
@@ -44466,7 +45020,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 176
+            "total": 196
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -44493,94 +45047,12 @@
     },
     {
       "type": "Feature",
-      "id": "a754ff83-4ca4-42e9-b42b-38d8db21a566",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.138025546102,
-          47.139029482434
-        ]
-      },
-      "properties": {
-        "uic": 8502008,
-        "didokId": "02008",
-        "operator": "SBB",
-        "displayName": "Nottwil",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 3",
-          "city": "Nottwil",
-          "postalCode": "6207"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "206"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 10
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "d62d04e4-90a3-4dd7-a190-a6a7810c1639",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.56179947473,
-          47.34945033027
+          8.562006066010111,
+          47.34920345198762
         ]
       },
       "properties": {
@@ -44666,8 +45138,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.047882382734,
-          47.356211697607
+          8.047648173769746,
+          47.356029732345284
         ]
       },
       "properties": {
@@ -44717,7 +45189,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 26
+            "total": 25
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -44753,8 +45225,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.709678,
-          47.285993
+          7.709732649727862,
+          47.28610422789339
         ]
       },
       "properties": {
@@ -44835,8 +45307,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.977519417197,
-          47.192070140647
+          7.977649686763195,
+          47.192044322027044
         ]
       },
       "properties": {
@@ -44913,103 +45385,12 @@
     },
     {
       "type": "Feature",
-      "id": "f22843bd-36a7-481b-b657-d55946c64e3d",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.2752653,
-          47.428125
-        ]
-      },
-      "properties": {
-        "uic": 8516219,
-        "didokId": "16219",
-        "operator": "SBB",
-        "displayName": "Mellingen-Heitersberg",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Bahnhofstrasse 80",
-          "city": "Mellingen-Heitersberg",
-          "postalCode": "5507"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 700,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 7000,
-          "yearlyTicketPrice": 70000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "53"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 165
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 3
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 2
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "2 E-Ladestationen von E360 und swisscharge  Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "2 e-charging stations from Energie 360 and swisscharge  This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "2 stazioni di ricarica elettronica di Energie 360 e swisscharge  Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "2 stations de recharge électronique d'Energie 360 et swisscharge  Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": {
-          "eChargingStationOperatorID": "30bd1b8b-b1a6-4957-9d02-eb607c1f9ec2",
-          "eChargingStationOperatorName": "swisscharge",
-          "eChargingStationOperatorLink": "https://map.swisscharge.ch/"
-        }
-      }
-    },
-    {
-      "type": "Feature",
       "id": "548718bf-d06d-448a-a503-283a02500000",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.234099187558,
-          47.414177325752
+          8.234131042909764,
+          47.414204732837604
         ]
       },
       "properties": {
@@ -45090,8 +45471,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.004621859386,
-          46.174352497259
+          9.004832702158893,
+          46.17442004134943
         ]
       },
       "properties": {
@@ -45145,7 +45526,7 @@
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 2
+            "total": 3
           },
           {
             "categoryType": "RESERVABLE_PARKING_SPACE",
@@ -45177,8 +45558,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.725100474799,
-          46.919378649467
+          7.724986402973297,
+          46.91929030522081
         ]
       },
       "properties": {
@@ -45264,8 +45645,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.253509859525,
-          47.492071743721
+          8.253913172965843,
+          47.49192905031444
         ]
       },
       "properties": {
@@ -45351,8 +45732,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.886069258722,
-          46.174578730918
+          8.886594489668774,
+          46.17396948066705
         ]
       },
       "properties": {
@@ -45433,8 +45814,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.255072288885,
-          46.862559864151
+          7.255304652467356,
+          46.86245519884059
         ]
       },
       "properties": {
@@ -45520,8 +45901,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.126407,
-          47.402852
+          8.126521578938254,
+          47.40294908899985
         ]
       },
       "properties": {
@@ -45546,8 +45927,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": null,
-          "yearlyTicketPrice": null,
+          "monthlyTicketPrice": 5000,
+          "yearlyTicketPrice": 50000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -45607,8 +45988,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.943960194057,
-          47.577378646787
+          8.944335002124891,
+          47.5773311176114
         ]
       },
       "properties": {
@@ -45689,8 +46070,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.978554954631,
-          45.902414572954
+          8.978494061736527,
+          45.90230854557929
         ]
       },
       "properties": {
@@ -45772,94 +46153,12 @@
     },
     {
       "type": "Feature",
-      "id": "869d9822-0b34-406f-94fe-98ba6c2f8305",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.849513482734,
-          46.145102042928
-        ]
-      },
-      "properties": {
-        "uic": 8505406,
-        "didokId": "05406",
-        "operator": "SBB",
-        "displayName": "Magadino-Vira",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "La Stazzión 8",
-          "city": "Magadino-Vira (Gambarogno)",
-          "postalCode": "6574"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "07:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "101"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 10
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "a79c43f9-68af-40ac-ba6c-cbfed43dcfd3",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.069451912828,
-          47.098159308571
+          9.06952881199389,
+          47.098194226707825
         ]
       },
       "properties": {
@@ -45940,8 +46239,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.058512,
-          47.136899
+          9.057860728019657,
+          47.13731165015707
         ]
       },
       "properties": {
@@ -46023,185 +46322,12 @@
     },
     {
       "type": "Feature",
-      "id": "1a647747-0521-4eb7-89fa-3b1de929adb1",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.457050547816,
-          47.245341016347
-        ]
-      },
-      "properties": {
-        "uic": 8502225,
-        "didokId": "02225",
-        "operator": "SBB",
-        "displayName": "Mettmenstetten",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Untere Bahnhofstrasse 20",
-          "city": "Mettmenstetten",
-          "postalCode": "8932"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 600,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 6000,
-          "yearlyTicketPrice": 60000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "324"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 98
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "e37346bf-0cca-408f-a40c-080a393a5a57",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.096314,
-          47.063329
-        ]
-      },
-      "properties": {
-        "uic": 8504226,
-        "didokId": "04226",
-        "operator": "SBB",
-        "displayName": "La Neuveville",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Place de la Gare 2",
-          "city": "La Neuveville",
-          "postalCode": "2520"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 50
-            },
-            {
-              "startingFrom": 120,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 3000,
-          "yearlyTicketPrice": 30000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "190"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 12
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "ff51377f-6e0c-4a4d-ab54-1fb3d1c7d6e0",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.932614540475,
-          46.038966258684
+          8.932734241010783,
+          46.0388279354831
         ]
       },
       "properties": {
@@ -46218,7 +46344,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 1000,
+          "maximumDayPrice": 1200,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -46272,88 +46398,6 @@
           "it": "Oltre al Parco Lamone-Cadempino, nel comune di Cadempino, a sud della stazione, sono disponibili 72 posti auto.\r\nGli abbonamenti annuali e mensili possono essere acquistati presso la biglietteria delle FFS.\r\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
           "fr": "En plus du parc Lamone-Cadempino, 72 places de parking sont disponibles dans la municipalité de Cadempino, au sud de la gare.\r\nLes abonnements annuels et mensuels peuvent être achetés au guichet CFF.\r\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "13680e0a-45a5-4f2d-ba1a-abd41b9b85b0",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          9.02955534313,
-          47.152220438286
-        ]
-      },
-      "properties": {
-        "uic": 8503224,
-        "didokId": "03224",
-        "operator": "SBB",
-        "displayName": "Bilten",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Speerstrasse 1",
-          "city": "Bilten",
-          "postalCode": "8865"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 400,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "06:00:00",
-          "operatingTo": "19:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "171"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 21
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
         "salesChannels": [
@@ -46451,8 +46495,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.9723031,
-          45.9333319
+          8.972505606212897,
+          45.933311099018404
         ]
       },
       "properties": {
@@ -46533,8 +46577,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.565785486647,
-          46.915145027487
+          7.5658843685574,
+          46.915097950613074
         ]
       },
       "properties": {
@@ -46616,176 +46660,12 @@
     },
     {
       "type": "Feature",
-      "id": "d5622d32-ed46-4a4e-b4a5-e197f2834b7b",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.609490401852,
-          46.527652004785
-        ]
-      },
-      "properties": {
-        "uic": 8505201,
-        "didokId": "05201",
-        "operator": "SBB",
-        "displayName": "Airolo",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Via della Stazione 29",
-          "city": "Airolo",
-          "postalCode": "6780"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "70"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 36
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "5cc50502-6c26-4055-9bf0-358fd3a07913",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.68986,
-          46.51075
-        ]
-      },
-      "properties": {
-        "uic": 8505202,
-        "didokId": "05202",
-        "operator": "SBB",
-        "displayName": "Ambrì-Piotta",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Ambri Road 43",
-          "city": "Ambrì-Piotta (Quinto)",
-          "postalCode": "6775"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 4000,
-          "yearlyTicketPrice": 40000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "71"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 11
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": null,
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
       "id": "c0610103-4ca7-4a0a-9ab0-cb13360ce280",
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.641527808598,
-          47.436774855806
+          9.641631809329551,
+          47.43686061528084
         ]
       },
       "properties": {
@@ -46866,8 +46746,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.173535,
-          47.582615
+          9.173474772834187,
+          47.582641647136136
         ]
       },
       "properties": {
@@ -47030,8 +46910,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.380849,
-          47.505999
+          8.381187053541927,
+          47.50598812109773
         ]
       },
       "properties": {
@@ -47112,8 +46992,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          9.266305677979,
-          47.621057269628
+          9.2670526975214,
+          47.620758411494286
         ]
       },
       "properties": {
@@ -47194,8 +47074,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.080981410867,
-          47.055417862185
+          8.081595851674518,
+          47.05536459756681
         ]
       },
       "properties": {
@@ -47212,7 +47092,7 @@
         "pricingModel": {
           "minimumDuration": 60,
           "maximumDuration": 10080,
-          "maximumDayPrice": 500,
+          "maximumDayPrice": 1000,
           "viableIncrement": 60,
           "priceSegments": [
             {
@@ -47245,7 +47125,7 @@
         "capacities": [
           {
             "categoryType": "STANDARD",
-            "total": 79
+            "total": 97
           },
           {
             "categoryType": "DISABLED_PARKING_SPACE",
@@ -47261,10 +47141,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
+          "de": "Aufgrund von Bauarbeiten steht ein eingeschränktes Parkplatzangebot zur Verfügung bis ca. Ende 2025.\nDiese Parkkasse geht in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. ",
+          "en": "Due to construction work, a limited number of parking spaces will be available until around the end of 2025.\nThis parking cash register has retired. But its successor, the P+R App, can do much more. ",
+          "it": "A causa dei lavori di costruzione, sarà disponibile un numero limitato di posti auto fino a circa la fine del 2025.\nQuesto parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
+          "fr": "En raison de travaux de construction, une offre limitée de places de stationnement est disponible jusqu'à fin 2025 environ.\nCette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -47281,8 +47161,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.747402,
-          46.800588
+          6.747559507202279,
+          46.80058839733428
         ]
       },
       "properties": {
@@ -47363,8 +47243,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.241240719911285,
-          46.9016473639298
+          7.242148503975832,
+          46.901486243328094
         ]
       },
       "properties": {
@@ -47445,8 +47325,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.586280982209,
-          47.520530998419
+          8.585891810562295,
+          47.52051310973015
         ]
       },
       "properties": {
@@ -47512,10 +47392,10 @@
           }
         ],
         "additionalInformationForCustomers": {
-          "de": ".",
-          "en": ".",
-          "it": ".",
-          "fr": "."
+          "de": "Ab November bis Ende März 2025 kommt es zu einer Teilsperrung. Parkplatz 1-8 können aufgrund von Bauarbeiten nicht genutzt werden. ",
+          "en": "From November until the end of March 2025, there will be a partial closure. Parking spaces 1-8 will not be available due to construction work.",
+          "it": "Da novembre fino alla fine di marzo 2025, ci sarà una chiusura parziale. I parcheggi 1-8 non saranno utilizzabili a causa di lavori di costruzione.",
+          "fr": "À partir de novembre jusqu'à fin mars 2025, il y aura une fermeture partielle. Les parkings 1 à 8 ne pourront pas être utilisés en raison de travaux de construction."
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -47532,8 +47412,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.557928,
-          47.431656
+          8.558081050523036,
+          47.43154504390232
         ]
       },
       "properties": {
@@ -47558,8 +47438,8 @@
               "price": 100
             }
           ],
-          "monthlyTicketPrice": 8000,
-          "yearlyTicketPrice": 80000,
+          "monthlyTicketPrice": 10000,
+          "yearlyTicketPrice": 100000,
           "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
           "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
         },
@@ -47601,95 +47481,8 @@
         "additionalInformationForCustomers": {
           "de": "Die Parkuhr ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr.",
           "en": "The parking meter is retired. But the P+Rail app can do much more.",
-          "it": " Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
+          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore.",
           "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux."
-        },
-        "parkingFacilityCategory": "CAR",
-        "parkingFacilityType": "PARK_AND_RAIL",
-        "salesChannels": [
-          "ONLINE_AND_AUTOMAT"
-        ],
-        "bikeFacilityTraits": [],
-        "eChargingStationOperator": null
-      }
-    },
-    {
-      "type": "Feature",
-      "id": "9b7100e6-6d93-4685-b57f-c23f698b8ea4",
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          7.688913806677,
-          47.522644429557
-        ]
-      },
-      "properties": {
-        "uic": 8500021,
-        "didokId": "00021",
-        "operator": "SBB",
-        "displayName": "Pratteln",
-        "publicAccess": true,
-        "address": {
-          "addressLine": "Güterstrasse 19",
-          "city": "Pratteln",
-          "postalCode": "4133"
-        },
-        "pricingModel": {
-          "minimumDuration": 60,
-          "maximumDuration": 10080,
-          "maximumDayPrice": 500,
-          "viableIncrement": 60,
-          "priceSegments": [
-            {
-              "startingFrom": 0,
-              "price": 100
-            }
-          ],
-          "monthlyTicketPrice": 5000,
-          "yearlyTicketPrice": 50000,
-          "monthlyTicketPriceWithPublicTransportSeasonTicketDiscount": null,
-          "yearlyTicketPriceWithPublicTransportSeasonTicketDiscount": null
-        },
-        "operationTime": {
-          "operatingFrom": "00:00:00",
-          "operatingTo": "00:00:00",
-          "daysOfWeek": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
-        },
-        "bookingSystem": {
-          "type": "NOVA",
-          "id": "197"
-        },
-        "capacities": [
-          {
-            "categoryType": "STANDARD",
-            "total": 58
-          },
-          {
-            "categoryType": "DISABLED_PARKING_SPACE",
-            "total": 1
-          },
-          {
-            "categoryType": "RESERVABLE_PARKING_SPACE",
-            "total": 0
-          },
-          {
-            "categoryType": "WITH_CHARGING_STATION",
-            "total": 0
-          }
-        ],
-        "additionalInformationForCustomers": {
-          "de": "Diese Parkkasse ist in Pension. Ihre Nachfolgerin, die P+R App, kann aber noch viel mehr. Jetzt herunterladen unter www.sbb.ch/parking",
-          "en": "This parking cash register has retired. But its successor, the P+R App, can do much more. ",
-          "it": "Questo parchimetro va in pensione. Ma la sua sostituta, l’app P+R, è ancora migliore. ",
-          "fr": "Cette caisse prend sa retraite. Mais sa remplaçante, l’appli P+R, est encore mieux. "
         },
         "parkingFacilityCategory": "CAR",
         "parkingFacilityType": "PARK_AND_RAIL",
@@ -47706,8 +47499,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.941128649004,
-          46.152428584328
+          8.941104616064353,
+          46.15246986961615
         ]
       },
       "properties": {
@@ -47788,8 +47581,8 @@
       "geometry": {
         "type": "Point",
         "coordinates": [
-          6.237813066201,
-          46.385694857023
+          6.237978640193018,
+          46.38580182618247
         ]
       },
       "properties": {
@@ -47801,7 +47594,7 @@
         "address": {
           "addressLine": "Rue des Marchandises 17",
           "city": "Nyon",
-          "postalCode": "1260"
+          "postalCode": "12600"
         },
         "pricingModel": {
           "minimumDuration": 60,

--- a/tests/converters/opendata_swiss_test.py
+++ b/tests/converters/opendata_swiss_test.py
@@ -31,7 +31,7 @@ def requests_mock_opendata_swiss(requests_mock: Mocker) -> Mocker:
         json_data = json_file.read()
 
     requests_mock.get(
-        'https://data.opentransportdata.swiss/dataset/parking-facilities/permalink',
+        'https://data.opentransportdata.swiss/de/dataset/parking-facilities/permalink',
         text=json_data,
     )
 

--- a/tests/converters/opendata_swiss_test.py
+++ b/tests/converters/opendata_swiss_test.py
@@ -31,7 +31,7 @@ def requests_mock_opendata_swiss(requests_mock: Mocker) -> Mocker:
         json_data = json_file.read()
 
     requests_mock.get(
-        'https://opentransportdata.swiss/de/dataset/parking-facilities/permalink',
+        'https://data.opentransportdata.swiss/dataset/parking-facilities/permalink',
         text=json_data,
     )
 
@@ -53,7 +53,7 @@ class OpenDataSwissPullConverterTest:
             opendata_swiss_pull_converter.get_static_parking_sites()
         )
 
-        assert len(static_parking_site_inputs) == 563
+        assert len(static_parking_site_inputs) == 560
         assert len(import_parking_site_exceptions) == 0
 
         validate_static_parking_site_inputs(static_parking_site_inputs)


### PR DESCRIPTION
This PR changes the source_url of Open-Data Swiss to the new URL, as announced by the Platform. Data will be available over the current URL until 5th Feb 2025.