### PR TITLE
fix bahn converter by creating session for client certs

### DIFF
--- a/src/parkapi_sources/converters/bahn_v2/converter.py
+++ b/src/parkapi_sources/converters/bahn_v2/converter.py
@@ -79,7 +79,6 @@ class BahnV2PullConverter(PullConverter):
             'DB-Client-Id': self.config_helper.get('PARK_API_BAHN_API_CLIENT_ID'),
             'DB-Api-Key': self.config_helper.get('PARK_API_BAHN_API_CLIENT_SECRET'),
             'Accept': 'application/vnd.parkinginformation.db-bahnpark.v1+json',
-            'accept': 'application/json',
         }
 
         response = requests.get(

--- a/src/parkapi_sources/converters/base_converter/pull/mobilithek_pull_converter.py
+++ b/src/parkapi_sources/converters/base_converter/pull/mobilithek_pull_converter.py
@@ -65,14 +65,16 @@ class MobilithekPullConverter(PullConverter, ABC):
             f'https://mobilithek.info:8443/mobilithek/api/v1.0/subscription/{subscription_id}'
             f'/clientPullService?subscriptionID={subscription_id}'
         )
-        response = requests.get(
-            url,
-            timeout=30,
-            cert=(
-                self.config_helper.get('PARK_API_MOBILITHEK_CERT'),
-                self.config_helper.get('PARK_API_MOBILITHEK_KEY'),
-            ),
-        )
+        # Create an isolated session, because cert is set globally otherwise
+        with requests.Session() as session:
+            response = session.get(
+                url,
+                timeout=30,
+                cert=(
+                    self.config_helper.get('PARK_API_MOBILITHEK_CERT'),
+                    self.config_helper.get('PARK_API_MOBILITHEK_KEY'),
+                ),
+            )
         self.handle_debug_request_response(response)
 
         root = etree.fromstring(response.text, parser=etree.XMLParser(resolve_entities=False))  # noqa: S320


### PR DESCRIPTION
Turns out that cert is part of the session, not part of the request, so the client cert is sent to EVERY url after it's set the first time at vrs, which makes bahn fail.