### PR TITLE
Smaller Freiburg Disabled Enhancements

### DIFF
--- a/docs/mapping/freiburg_disabled_sensors.md
+++ b/docs/mapping/freiburg_disabled_sensors.md
@@ -2,6 +2,12 @@
 
 Freiburg provides a GeoJSON with sensor-enabled parking spots.
 
+
+* `restricted_to.type` is set to `DISABLED`
+* `purpose` is set to `CAR`
+* `has_realtime_data` is set to `true`
+* `static_data_updated_at` is set to the moment of import
+
 ## Properties
 
 | Field     | Type              | Cardinality | Mapping         | Comment                                                       |

--- a/docs/mapping/freiburg_disabled_static.md
+++ b/docs/mapping/freiburg_disabled_static.md
@@ -2,13 +2,19 @@
 
 Freiburg provides a GeoJSON with static parking spots. lat / lon are set to the center of the GeoJSON polygon.
 
+
+* `restricted_to.type` is set to `DISABLED`
+* `purpose` is set to `CAR`
+* `has_realtime_data` is set to `false`
+* `static_data_updated_at` is set to the moment of import
+
 ## Properties
 
-| Field      | Type   | Cardinality | Mapping     | Comment                        |
-|------------|--------|-------------|-------------|--------------------------------|
-| fid        | string | 1           | uid         |                                |
-| strasse    | string | 1           | address     |                                |
-| hausnummer | string | 1           | address     | Will be omitted if emptystring |
-| anzahl     | string | 1           |             |                                |
-| hinweis    | string | 1           | description |                                |
-| stadtteil  | string | 1           |             |                                |
+| Field      | Type   | Cardinality | Mapping     | Comment                                                                |
+|------------|--------|-------------|-------------|------------------------------------------------------------------------|
+| fid        | string | 1           | uid         |                                                                        |
+| strasse    | string | 1           | address     | Address without locality, therefore ', Freiburg im Breisgau' is added. |
+| hausnummer | string | 1           | address     | Will be omitted if emptystring.                                        |
+| anzahl     | string | 1           |             |                                                                        |
+| hinweis    | string | 1           | description |                                                                        |
+| stadtteil  | string | 1           |             |                                                                        |

--- a/src/parkapi_sources/converters/freiburg_disabled_sensors/models.py
+++ b/src/parkapi_sources/converters/freiburg_disabled_sensors/models.py
@@ -9,8 +9,13 @@ from enum import Enum
 from validataclass.dataclasses import validataclass
 from validataclass.validators import DataclassValidator, EnumValidator, RegexValidator, StringValidator
 
-from parkapi_sources.models import GeojsonBaseFeatureInput, RealtimeParkingSpotInput, StaticParkingSpotInput
-from parkapi_sources.models.enums import ParkingSpotStatus
+from parkapi_sources.models import (
+    GeojsonBaseFeatureInput,
+    ParkingRestrictionInput,
+    RealtimeParkingSpotInput,
+    StaticParkingSpotInput,
+)
+from parkapi_sources.models.enums import ParkingAudience, ParkingSpotStatus, PurposeType
 
 
 class FreiburgDisabledStatus(Enum):
@@ -44,6 +49,8 @@ class FreiburgDisabledSensorFeatureInput(GeojsonBaseFeatureInput):
             lat=self.geometry.coordinates[1],
             lon=self.geometry.coordinates[0],
             has_realtime_data=True,
+            restricted_to=[ParkingRestrictionInput(type=ParkingAudience.DISABLED)],
+            purpose=PurposeType.CAR,
         )
 
     def to_realtime_parking_spot_input(self) -> RealtimeParkingSpotInput:

--- a/src/parkapi_sources/converters/freiburg_disabled_static/models.py
+++ b/src/parkapi_sources/converters/freiburg_disabled_static/models.py
@@ -11,7 +11,13 @@ import shapely
 from validataclass.dataclasses import validataclass
 from validataclass.validators import DataclassValidator, IntegerValidator, StringValidator
 
-from parkapi_sources.models import GeojsonBaseFeatureInput, GeojsonFeatureGeometryPolygonInput, StaticParkingSpotInput
+from parkapi_sources.models import (
+    GeojsonBaseFeatureInput,
+    GeojsonFeatureGeometryPolygonInput,
+    ParkingRestrictionInput,
+    StaticParkingSpotInput,
+)
+from parkapi_sources.models.enums import ParkingAudience, PurposeType
 from parkapi_sources.models.parking_spot_inputs import GeojsonPolygonInput
 from parkapi_sources.util import round_7d
 
@@ -33,6 +39,7 @@ class FreiburgDisabledStaticFeatureInput(GeojsonBaseFeatureInput):
         address = self.properties.strasse
         if self.properties.hausnummer:
             address += f' {self.properties.hausnummer}'
+        address += ', Freiburg im Breisgau'
 
         geojson = GeojsonPolygonInput(
             type='Polygon',
@@ -51,4 +58,6 @@ class FreiburgDisabledStaticFeatureInput(GeojsonBaseFeatureInput):
             lon=round_7d(Decimal(point.x)),
             has_realtime_data=False,
             geojson=geojson,
+            restricted_to=[ParkingRestrictionInput(type=ParkingAudience.DISABLED)],
+            purpose=PurposeType.CAR,
         )


### PR DESCRIPTION
Adds `DISABLED` restriction to both Freiburg disabled converters, and locality name to the static one. Adds more docs about static values.