### PR TITLE
Fixed realtime_opening_status logic

### DIFF
--- a/src/parkapi_sources/converters/freiburg/models.py
+++ b/src/parkapi_sources/converters/freiburg/models.py
@@ -146,5 +146,5 @@ class FreiburgParkAndRideRealtimeFeatureInput(FreiburgBaseFeatureInput):
             realtime_capacity=self.properties.obs_max,
             realtime_free_capacity=self.properties.obs_free,
             realtime_data_updated_at=self.properties.obs_ts,
-            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state == 1 else OpeningStatus.CLOSED,
+            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state >= 0 else OpeningStatus.CLOSED,
         )


### PR DESCRIPTION
This PR fixes the logic of the `realtime_opening_status` for the Park and Ride realtime data.