### PR TITLE
Set realtime_opening_status=CLOSED when obs_state=0

### DIFF
--- a/docs/mapping/freiburg.md
+++ b/docs/mapping/freiburg.md
@@ -6,14 +6,14 @@ The city of Freiburg provides realtime ``GEOJSON`` parking data for cars.
 
 A `ParkingSites` provides realtime data for a `ParkingSite`.
 
-| Field                      | Type                     | Cardinality | Mapping                         | Comment                                                             |
-|----------------------------|--------------------------|-------------|---------------------------------|---------------------------------------------------------------------|
-| obs_parkid                 | integer                  | 1           | uid                             |                                                                     |
-| obs_max                    | integer                  | 1           | realtime_capacity/capacity      |                                                                     |
-| obs_free                   | integer                  | 1           | realtime_free_capacity          |                                                                     |
-| obs_ts                     | datetime                 | 1           | realtime_data_updated_at        |                                                                     |
+| Field                      | Type                     | Cardinality | Mapping                                            | Comment                                                             |
+|----------------------------|--------------------------|-------------|----------------------------------------------------|---------------------------------------------------------------------|
+| obs_parkid                 | integer                  | 1           | uid                                                |                                                                     |
+| obs_max                    | integer                  | 1           | realtime_capacity/capacity                         |                                                                     |
+| obs_free                   | integer                  | 1           | realtime_free_capacity                             |                                                                     |
+| obs_ts                     | datetime                 | 1           | realtime_data_updated_at                           |                                                                     |
 | obs_state                  | integer                  | 1           | [realtime_opening_status](#RealtimeOpeningStatus)  |                                                                     |
-| public_url                 | string                   | ?           | public_url                      |                                                                     |
+| public_url                 | string                   | ?           | public_url                                         |                                                                     |
 
 
 #### RealtimeOpeningStatus

--- a/docs/mapping/freiburg.md
+++ b/docs/mapping/freiburg.md
@@ -2,6 +2,28 @@
 
 The city of Freiburg provides realtime ``GEOJSON`` parking data and also static nd realtime Park + Ride data for cars.
 
+#### RealtimeOpeningStatus
+
+| Key        | Mapping        | Comment                                                                                                                    |
+|------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| 0          | OPEN           | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar) for [P+R Realtime](#P+R-Realtime)  |
+| 0          | CLOSED         | No data (Störung / Keine Daten) for Normal [ParkingSite](#ParkingSites)                                                    |
+| 1          | OPEN           | Less than 30 parking spaces (Weniger als 30 Restplätze)                                                                    |
+| 2          | OPEN           | Less than 10 parking spaces (Weniger als 10 Restplätze)                                                                    |
+| -1         | CLOSED         | No data (Störung / Keine Daten)                                                                                            |
+
+
+#### ParkingSiteType
+
+| Key           | Mapping                        |
+|---------------|--------------------------------|
+| Parkplatz     | OFF_STREET_PARKING_GROUND      |
+| Parkhaus      | CAR_PARK                       |
+| Tiefgarage    | UNDERGROUND                    |
+| Park&Ride     | OFF_STREET_PARKING_GROUND      |
+| None          | OTHER                          |
+
+
 ## ParkingSites
 
 A `ParkingSites` provides realtime data for a `ParkingSite`.
@@ -16,7 +38,7 @@ A `ParkingSites` provides realtime data for a `ParkingSite`.
 | public_url                 | string                   | ?           | public_url                      |                                                                     |
 
 
-## ParkingSites for P+R Static
+##  P+R-Static ParkingSites
 
 Attributes which are set statically:
 * `has_realtime_data` is always set to `False`
@@ -32,7 +54,7 @@ A `ParkingSites` provides static data for a Park and Ride `ParkingSite`.
 | kategorie                  | string                   | 1           | [type](#ParkingSiteType)        |                                                                     |
 
 
-## ParkingSites for P+R Realtime and Static
+## P+R-Realtime and Static ParkingSites 
 
 Attributes which are set statically:
 * `type` is always set to `OFF_STREET_PARKING_GROUND`
@@ -50,24 +72,3 @@ A `ParkingSites` provides static and realtime data for a Park and Ride `ParkingS
 | obs_free                   | integer                  | 1           | realtime_free_capacity                             |                                                                     |
 | obs_ts                     | datetime                 | 1           | realtime_data_updated_at                           |                                                                     |
 | obs_state                  | integer                  | 1           | [realtime_opening_status](#RealtimeOpeningStatus)  |                                                                     |
-
-
-#### RealtimeOpeningStatus
-
-| Key        | Mapping   | Comment                                                          |
-|------------|-----------|------------------------------------------------------------------|
-| 0          | OPEN      | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar)      |
-| 1          | OPEN      | Less than 30 parking spaces (Weniger als 30 Restplätze)          |
-| 2          | OPEN      | Less than 10 parking spaces (Weniger als 10 Restplätze)          |
-| -1         | CLOSED    | No data (Störung / Keine Daten)                                  |
-
-
-#### ParkingSiteType
-
-| Key           | Mapping                        |
-|---------------|--------------------------------|
-| Parkplatz     | OFF_STREET_PARKING_GROUND      |
-| Parkhaus      | CAR_PARK                       |
-| Tiefgarage    | UNDERGROUND                    |
-| Park&Ride     | OFF_STREET_PARKING_GROUND      |
-| None          | OTHER                          |

--- a/docs/mapping/freiburg.md
+++ b/docs/mapping/freiburg.md
@@ -1,29 +1,6 @@
 # Realtime and Static data of the city of Freiburg
 
-The city of Freiburg provides realtime ``GEOJSON`` parking data and also static nd realtime Park + Ride data for cars.
-
-#### RealtimeOpeningStatus
-
-| Key        | Mapping        | Comment                                                                                                        |
-|------------|----------------|----------------------------------------------------------------------------------------------------------------|
-| 0          | OPEN           | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar) for [P+R Realtime ParkingSites](#P+R-Realtime)     |
-| 1          | OPEN           | Less than 30 parking spaces (Weniger als 30 Restplätze) for [P+R Realtime ParkingSites](#P+R-Realtime)         |
-| 2          | OPEN           | Less than 10 parking spaces (Weniger als 10 Restplätze) for [P+R Realtime ParkingSites](#P+R-Realtime)         |
-| -1         | CLOSED         | No data (Störung / Keine Daten) for [P+R Realtime ParkingSites](#P+R-Realtime)                                 |
-| 0          | CLOSED         | No data (Störung / Keine Daten) for [Normal ParkingSites](#ParkingSites)                                       |
-| 1          | OPEN           | Free parking spaces for [Normal ParkingSites](#ParkingSites)                                                   |
-
-
-#### ParkingSiteType
-
-| Key           | Mapping                        |
-|---------------|--------------------------------|
-| Parkplatz     | OFF_STREET_PARKING_GROUND      |
-| Parkhaus      | CAR_PARK                       |
-| Tiefgarage    | UNDERGROUND                    |
-| Park&Ride     | OFF_STREET_PARKING_GROUND      |
-| None          | OTHER                          |
-
+The city of Freiburg provides realtime ``GEOJSON`` parking data for cars.
 
 ## ParkingSites
 
@@ -39,37 +16,20 @@ A `ParkingSites` provides realtime data for a `ParkingSite`.
 | public_url                 | string                   | ?           | public_url                      |                                                                     |
 
 
-##  P+R-Static ParkingSites
+#### RealtimeOpeningStatus
 
-Attributes which are set statically:
-* `has_realtime_data` is always set to `False`
-
-A `ParkingSites` provides static data for a Park and Ride `ParkingSite`.
-
-| Field                      | Type                     | Cardinality | Mapping                         | Comment                                                             |
-|----------------------------|--------------------------|-------------|---------------------------------|---------------------------------------------------------------------|
-| ogc_fid                    | integer                  | 1           | uid                             |                                                                     |
-| kapazitaet                 | integer                  | 1           | capacity                        |                                                                     |
-| name                       | string                   | 1           | name                            |                                                                     |
-| nummer                     | string                   | 1           | name                            | Empyt strings will be ignored                                       |
-| kategorie                  | string                   | 1           | [type](#ParkingSiteType)        |                                                                     |
+| Key        | Mapping        | Comment                                    |
+|------------|----------------|--------------------------------------------|
+| 0          | CLOSED         | No data (Störung / Keine Daten)            |
+| 1          | OPEN           | Free parking spaces                        |
 
 
-## P+R-Realtime and Static ParkingSites 
+#### ParkingSiteType
 
-Attributes which are set statically:
-* `type` is always set to `OFF_STREET_PARKING_GROUND`
-* `park_and_ride_type` is always set to `['YES']`
-* `purpose` is always set to `CAR`
-* `has_realtime_data` is always set to `True`
-
-A `ParkingSites` provides static and realtime data for a Park and Ride `ParkingSite`.
-
-| Field                      | Type                     | Cardinality | Mapping                                            | Comment                                                             |
-|----------------------------|--------------------------|-------------|----------------------------------------------------|---------------------------------------------------------------------|
-| park_id                    | integer                  | 1           | uid                                                |                                                                     |
-| name                       | string                   | 1           | name                                               |                                                                     |
-| obs_max                    | integer                  | 1           | realtime_capacity/capacity                         |                                                                     |
-| obs_free                   | integer                  | 1           | realtime_free_capacity                             |                                                                     |
-| obs_ts                     | datetime                 | 1           | realtime_data_updated_at                           |                                                                     |
-| obs_state                  | integer                  | 1           | [realtime_opening_status](#RealtimeOpeningStatus)  |                                                                     |
+| Key           | Mapping                        |
+|---------------|--------------------------------|
+| Parkplatz     | OFF_STREET_PARKING_GROUND      |
+| Parkhaus      | CAR_PARK                       |
+| Tiefgarage    | UNDERGROUND                    |
+| Park&Ride     | OFF_STREET_PARKING_GROUND      |
+| None          | OTHER                          |

--- a/docs/mapping/freiburg.md
+++ b/docs/mapping/freiburg.md
@@ -4,13 +4,14 @@ The city of Freiburg provides realtime ``GEOJSON`` parking data and also static 
 
 #### RealtimeOpeningStatus
 
-| Key        | Mapping        | Comment                                                                                                                    |
-|------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
-| 0          | OPEN           | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar) for [P+R Realtime](#P+R-Realtime)  |
-| 0          | CLOSED         | No data (Störung / Keine Daten) for Normal [ParkingSite](#ParkingSites)                                                    |
-| 1          | OPEN           | Less than 30 parking spaces (Weniger als 30 Restplätze)                                                                    |
-| 2          | OPEN           | Less than 10 parking spaces (Weniger als 10 Restplätze)                                                                    |
-| -1         | CLOSED         | No data (Störung / Keine Daten)                                                                                            |
+| Key        | Mapping        | Comment                                                                                                        |
+|------------|----------------|----------------------------------------------------------------------------------------------------------------|
+| 0          | OPEN           | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar) for [P+R Realtime ParkingSites](#P+R-Realtime)     |
+| 1          | OPEN           | Less than 30 parking spaces (Weniger als 30 Restplätze) for [P+R Realtime ParkingSites](#P+R-Realtime)         |
+| 2          | OPEN           | Less than 10 parking spaces (Weniger als 10 Restplätze) for [P+R Realtime ParkingSites](#P+R-Realtime)         |
+| -1         | CLOSED         | No data (Störung / Keine Daten) for [P+R Realtime ParkingSites](#P+R-Realtime)                                 |
+| 0          | CLOSED         | No data (Störung / Keine Daten) for [Normal ParkingSites](#ParkingSites)                                       |
+| 1          | OPEN           | Free parking spaces for [Normal ParkingSites](#ParkingSites)                                                   |
 
 
 #### ParkingSiteType

--- a/docs/mapping/freiburg_p_r.md
+++ b/docs/mapping/freiburg_p_r.md
@@ -1,0 +1,57 @@
+# Realtime and Static P+R data of the city of Freiburg
+
+The city of Freiburg provides realtime ``GEOJSON`` parking data for static and realtime Park + Ride for cars.
+
+##  P+R-Static ParkingSites
+
+Attributes which are set statically:
+* `has_realtime_data` is always set to `False`
+
+A `ParkingSites` provides static data for a Park and Ride `ParkingSite`.
+
+| Field                      | Type                     | Cardinality | Mapping                         | Comment                                                             |
+|----------------------------|--------------------------|-------------|---------------------------------|---------------------------------------------------------------------|
+| ogc_fid                    | integer                  | 1           | uid                             |                                                                     |
+| kapazitaet                 | integer                  | 1           | capacity                        |                                                                     |
+| name                       | string                   | 1           | name                            |                                                                     |
+| nummer                     | string                   | 1           | name                            | Empty strings will be ignored                                       |
+| kategorie                  | string                   | 1           | [type](#ParkingSiteType)        |                                                                     |
+
+
+## P+R-Realtime and Static ParkingSites 
+
+Attributes which are set statically:
+* `type` is always set to `OFF_STREET_PARKING_GROUND`
+* `park_and_ride_type` is always set to `['YES']`
+* `purpose` is always set to `CAR`
+* `has_realtime_data` is always set to `True`
+
+A `ParkingSites` provides static and realtime data for a Park and Ride `ParkingSite`.
+
+| Field                      | Type                     | Cardinality | Mapping                                            | Comment                                                             |
+|----------------------------|--------------------------|-------------|----------------------------------------------------|---------------------------------------------------------------------|
+| park_id                    | integer                  | 1           | uid                                                |                                                                     |
+| name                       | string                   | 1           | name                                               |                                                                     |
+| obs_max                    | integer                  | 1           | realtime_capacity/capacity                         |                                                                     |
+| obs_free                   | integer                  | 1           | realtime_free_capacity                             |                                                                     |
+| obs_ts                     | datetime                 | 1           | realtime_data_updated_at                           |                                                                     |
+| obs_state                  | integer                  | 1           | [realtime_opening_status](#RealtimeOpeningStatus)  |                                                                     |
+
+#### RealtimeOpeningStatus
+
+| Key        | Mapping        | Comment                                                         |
+|------------|----------------|-----------------------------------------------------------------|
+| 0          | OPEN           | Free parking spaces (Normalbetrieb, Freie Plätze verfügbar)     |
+| 1          | OPEN           | Less than 30 parking spaces (Weniger als 30 Restplätze)         |
+| 2          | OPEN           | Less than 10 parking spaces (Weniger als 10 Restplätze)         |
+| -1         | CLOSED         | No data (Störung / Keine Daten)                                 |
+
+#### ParkingSiteType
+
+| Key           | Mapping                        |
+|---------------|--------------------------------|
+| Parkplatz     | OFF_STREET_PARKING_GROUND      |
+| Parkhaus      | CAR_PARK                       |
+| Tiefgarage    | UNDERGROUND                    |
+| Park&Ride     | OFF_STREET_PARKING_GROUND      |
+| None          | OTHER                          |

--- a/src/parkapi_sources/converters/freiburg/models.py
+++ b/src/parkapi_sources/converters/freiburg/models.py
@@ -93,7 +93,7 @@ class FreiburgFeatureInput(FreiburgBaseFeatureInput):
             realtime_capacity=self.properties.obs_max,
             realtime_free_capacity=self.properties.obs_free,
             realtime_data_updated_at=self.properties.obs_ts,
-            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state > 0 else OpeningStatus.CLOSED,
+            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state == 1 else OpeningStatus.CLOSED,
         )
 
 

--- a/src/parkapi_sources/converters/freiburg/models.py
+++ b/src/parkapi_sources/converters/freiburg/models.py
@@ -22,7 +22,7 @@ class FreiburgPropertiesInput:
     obs_id: int = IntegerValidator(allow_strings=True)
     obs_parkid: int = IntegerValidator(allow_strings=True)
     obs_state: int = IntegerValidator(allow_strings=True)
-    obs_max: int = IntegerValidator(allow_strings=True)
+    obs_max: int = IntegerValidator(min_value=1, allow_strings=True)
     obs_free: int = IntegerValidator(allow_strings=True)
     obs_ts: datetime = SpacedDateTimeValidator(
         local_timezone=ZoneInfo('Europe/Berlin'),
@@ -54,13 +54,13 @@ class FreiburgParkAndRideStaticPropertiesInput:
     name: str = StringValidator()
     nummer: str = StringValidator()
     kategorie: FreiburgParkingSiteTypeInput = EnumValidator(FreiburgParkingSiteTypeInput)
-    kapazitaet: int = IntegerValidator(allow_strings=True)
+    kapazitaet: int = IntegerValidator(min_value=1, allow_strings=True)
 
 
 @validataclass
 class FreiburgParkAndRideRealtimePropertiesInput:
     obs_state: int = IntegerValidator(allow_strings=True)
-    obs_max: int = IntegerValidator(allow_strings=True)
+    obs_max: int = IntegerValidator(min_value=1, allow_strings=True)
     obs_free: int = IntegerValidator(allow_strings=True)
     obs_ts: datetime = SpacedDateTimeValidator(
         local_timezone=ZoneInfo('Europe/Berlin'),
@@ -93,7 +93,7 @@ class FreiburgFeatureInput(FreiburgBaseFeatureInput):
             realtime_capacity=self.properties.obs_max,
             realtime_free_capacity=self.properties.obs_free,
             realtime_data_updated_at=self.properties.obs_ts,
-            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state >= 0 else OpeningStatus.CLOSED,
+            realtime_opening_status=OpeningStatus.OPEN if self.properties.obs_state > 0 else OpeningStatus.CLOSED,
         )
 
 

--- a/tests/converters/freiburg_test.py
+++ b/tests/converters/freiburg_test.py
@@ -61,7 +61,7 @@ class FreiburgPullConverterTest:
         static_parking_site_inputs, import_parking_site_exceptions = freiburg_pull_converter.get_static_parking_sites()
 
         assert len(static_parking_site_inputs) == 20
-        assert len(import_parking_site_exceptions) == 0
+        assert len(import_parking_site_exceptions) == 1
 
         validate_static_parking_site_inputs(static_parking_site_inputs)
 
@@ -73,8 +73,8 @@ class FreiburgPullConverterTest:
             freiburg_pull_converter.get_realtime_parking_sites()
         )
 
-        assert len(realtime_parking_site_inputs) == 19
-        assert len(import_parking_site_exceptions) == 0
+        assert len(realtime_parking_site_inputs) == 18
+        assert len(import_parking_site_exceptions) == 1
 
         validate_realtime_parking_site_inputs(realtime_parking_site_inputs)
 
@@ -97,7 +97,7 @@ class FreiburgPullConverterTest:
         )
 
         assert len(static_parking_site_inputs) == 20
-        assert len(import_parking_site_exceptions) == 0
+        assert len(import_parking_site_exceptions) == 1
 
         assert static_parking_site_inputs[0].name == 'New name'
 


### PR DESCRIPTION
This PR resolves this issue https://github.com/ParkenDD/parkapi-sources-v3/issues/240 and sets `obs-state=1` to `realtime_opening_status=OPEN` and `obs-state=0` to `realtime_opening_status=CLOSED`. This is according to the contact person from Freiburg.  

It also flags parking sites with `capacity=0` as `ValidationError`, thereby removing the site from the data.