### PR TITLE
Fix missing konstanz data: made realtime data optional

### DIFF
--- a/src/parkapi_sources/converters/konstanz/models.py
+++ b/src/parkapi_sources/converters/konstanz/models.py
@@ -92,8 +92,8 @@ class KonstanzParkingSiteDataInput:
     max_hei: int = EmptystringNoneable(KonstanzHeightValidator())
     opening_s: Optional[bool] = EmptystringNoneable(MappedBooleanValidator(mapping={'ja': True, 'nein': False}))
     updated: datetime = TimestampDateTimeValidator(divisor=1000)
-    real_capa: int = NumericIntegerValidator(min_value=0)
-    real_fcap: int = NumericIntegerValidator(min_value=0)
+    real_capa: Optional[int] = EmptystringNoneable(NumericIntegerValidator(min_value=0))
+    real_fcap: Optional[int] = EmptystringNoneable(NumericIntegerValidator(min_value=0))
 
     def to_static_parking_site(self) -> StaticParkingSiteInput:
         return StaticParkingSiteInput(


### PR DESCRIPTION
This PR fixes this issue https://github.com/ParkenDD/parkapi-sources-v3/issues/209 and makes `realtime_capacity` and `realtime_free_capacity`  `Optional` attributes.