### PR TITLE
herrenberg_bike: update to the new mapping

### DIFF
--- a/docs/mapping/herrenberg_bike.md
+++ b/docs/mapping/herrenberg_bike.md
@@ -31,14 +31,8 @@ The static data is provided over a GeoJSON API endpoint.
 | Bügel                         | `type` set to `STANDS`                                         |
 | Reine Vorderradhalterung      | `type` set to `WALL_LOOPS`                                     |
 | Bügel + Vorderradhalterung    | `type` set to `SAFE_WALL_LOOPS`                                |
-| Fahrradboxen                  | `type` set to `LOCKERS`                                        |
-| lean_and_stick                | `type` set to `STANDS`                                         |
-| Holzkonstruktion              | `type` set to `FLOOR`                                           |
-| Nische zum Abstellen          | `type` set to `FLOOR`                                          |
-| Stange                        | `type` set to `STANDS`                                         |
-| safe_loops                    | `type` set to `SAFE_WALL_LOOPS`                                |
-| lockers                       | `type` set to `LOCKERS`                                        |
-
+| Schließfächer/ Boxen          | `type` set to `LOCKERS`                                        |
+| andere                        | `type` set to `FLOOR`                                          |
 
 ## IsCovered
 


### PR DESCRIPTION
City of Herrenberg completely changed all attributes in their dataset for bike parking and also switched to new endpoint. Therefore, a new mapping is developed to re-integrate the dataset.