### PR TITLE
enforce purpose

### DIFF
--- a/src/parkapi_sources/converters/aalen/converter.py
+++ b/src/parkapi_sources/converters/aalen/converter.py
@@ -11,7 +11,7 @@ from parkapi_sources.converters.base_converter.pull import (
     StaticGeojsonDataMixin,
 )
 from parkapi_sources.exceptions import ImportParkingSiteException
-from parkapi_sources.models import RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import PurposeType, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
 
 from .models import AalenInput
 
@@ -28,7 +28,10 @@ class AalenPullConverter(ParkingSitePullConverter, StaticGeojsonDataMixin):
     )
 
     def get_static_parking_sites(self) -> tuple[list[StaticParkingSiteInput], list[ImportParkingSiteException]]:
-        return self._get_static_parking_site_inputs_and_exceptions(source_uid=self.source_info.uid)
+        return self._get_static_parking_site_inputs_and_exceptions(
+            source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
+        )
 
     def get_realtime_parking_sites(self) -> tuple[list[RealtimeParkingSiteInput], list[ImportParkingSiteException]]:
         realtime_parking_site_inputs: list[RealtimeParkingSiteInput] = []

--- a/src/parkapi_sources/converters/base_converter/pull/static_geojson_mixin.py
+++ b/src/parkapi_sources/converters/base_converter/pull/static_geojson_mixin.py
@@ -19,6 +19,7 @@ from parkapi_sources.models import (
     GeojsonFeatureInput,
     GeojsonFeatureParkingSpotInput,
     GeojsonInput,
+    PurposeType,
     SourceInfo,
     StaticParkingSiteInput,
     StaticParkingSpotInput,
@@ -89,6 +90,7 @@ class StaticGeojsonDataMixin(ABC):
     def _get_static_parking_site_inputs_and_exceptions(
         self,
         source_uid: str,
+        purpose: PurposeType,
     ) -> tuple[list[StaticParkingSiteInput], list[ImportParkingSiteException]]:
         static_parking_site_inputs: list[StaticParkingSiteInput] = []
 
@@ -99,6 +101,7 @@ class StaticGeojsonDataMixin(ABC):
         for feature_input in feature_inputs:
             static_parking_site_inputs.append(
                 feature_input.to_static_parking_site_input(
+                    purpose=purpose,
                     # TODO: Use the Last-Updated HTTP header instead, but as Github does not set such an header, we
                     #  need to move all GeoJSON data in order to use this.
                     static_data_updated_at=datetime.now(tz=timezone.utc),
@@ -110,6 +113,7 @@ class StaticGeojsonDataMixin(ABC):
     def _get_static_parking_spots_inputs_and_exceptions(
         self,
         source_uid: str,
+        purpose: PurposeType,
     ) -> tuple[list[StaticParkingSpotInput], list[ImportParkingSpotException]]:
         static_parking_spot_inputs: list[StaticParkingSpotInput] = []
 
@@ -120,6 +124,7 @@ class StaticGeojsonDataMixin(ABC):
         for feature_input in feature_inputs:
             static_parking_spot_inputs.append(
                 feature_input.to_static_parking_spot_input(
+                    purpose=purpose,
                     # TODO: Use the Last-Updated HTTP header instead, but as Github does not set such an header, we
                     #  need to move all GeoJSON data in order to use this.
                     static_data_updated_at=datetime.now(tz=timezone.utc),

--- a/src/parkapi_sources/converters/base_converter/push/normalized_xlsx_converter.py
+++ b/src/parkapi_sources/converters/base_converter/push/normalized_xlsx_converter.py
@@ -12,7 +12,7 @@ from openpyxl.workbook.workbook import Workbook
 from validataclass.exceptions import ValidationError
 
 from parkapi_sources.exceptions import ImportParkingSiteException
-from parkapi_sources.models import ParkingAudience, StaticParkingSiteInput
+from parkapi_sources.models import ParkingAudience, PurposeType, StaticParkingSiteInput
 
 from .xlsx_converter import XlsxConverter
 
@@ -118,6 +118,7 @@ class NormalizedXlsxConverter(XlsxConverter, ABC):
             if isinstance(parking_site_dict['type'], str)
             else None
         )
+        parking_site_dict.setdefault('purpose', PurposeType.CAR.name)
         parking_site_dict['static_data_updated_at'] = datetime.now(tz=timezone.utc).isoformat()
 
         restrictions: list[tuple[str, ParkingAudience]] = [

--- a/src/parkapi_sources/converters/basel/models.py
+++ b/src/parkapi_sources/converters/basel/models.py
@@ -16,7 +16,7 @@ from validataclass.validators import (
     UrlValidator,
 )
 
-from parkapi_sources.models import ParkingSiteType, RealtimeParkingSiteInput, StaticParkingSiteInput
+from parkapi_sources.models import ParkingSiteType, PurposeType, RealtimeParkingSiteInput, StaticParkingSiteInput
 
 
 @validataclass
@@ -44,6 +44,7 @@ class BaselParkingSiteInput:
         return StaticParkingSiteInput(
             uid=self.id2,
             name=self.name,
+            purpose=PurposeType.CAR,
             lat=self.geo_point_2d.lat,
             lon=self.geo_point_2d.lon,
             capacity=self.total,

--- a/src/parkapi_sources/converters/bfrk_bw/car_models.py
+++ b/src/parkapi_sources/converters/bfrk_bw/car_models.py
@@ -32,6 +32,7 @@ from parkapi_sources.models.enums import (
     ParkingSiteType,
     ParkingSpotType,
     ParkingType,
+    PurposeType,
 )
 from parkapi_sources.util import generate_point, round_7d
 from parkapi_sources.validators import EmptystringNoneable, ReplacingStringValidator
@@ -188,6 +189,7 @@ class BfrkCarInput(BfrkBaseInput):
 
         static_parking_site_input = StaticParkingSiteInput(
             type=parking_site_type,
+            purpose=PurposeType.CAR,
             capacity=self.stellplaetzegesamt,
             description=self._get_description(),
             operator_name=self.eigentuemer,
@@ -258,6 +260,7 @@ class BfrkCarInput(BfrkBaseInput):
                     uid=f'{self.infraid}-{i}',
                     parking_site_uid=self.infraid,
                     name=name,
+                    purpose=PurposeType.CAR,
                     type=spot_type,
                     description=description,
                     static_data_updated_at=datetime.now(tz=timezone.utc),

--- a/src/parkapi_sources/converters/bietigheim_bissingen/converter.py
+++ b/src/parkapi_sources/converters/bietigheim_bissingen/converter.py
@@ -18,7 +18,7 @@ from parkapi_sources.converters.base_converter.pull import (
     StaticGeojsonDataMixin,
 )
 from parkapi_sources.exceptions import ImportParkingSiteException, ImportSourceException
-from parkapi_sources.models import RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import PurposeType, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
 
 from .models import BietigheimBissingenInput
 
@@ -36,7 +36,10 @@ class BietigheimBissingenPullConverter(ParkingSitePullConverter, StaticGeojsonDa
     )
 
     def get_static_parking_sites(self) -> tuple[list[StaticParkingSiteInput], list[ImportParkingSiteException]]:
-        return self._get_static_parking_site_inputs_and_exceptions(source_uid=self.source_info.uid)
+        return self._get_static_parking_site_inputs_and_exceptions(
+            source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
+        )
 
     def get_realtime_parking_sites(self) -> tuple[list[RealtimeParkingSiteInput], list[ImportParkingSiteException]]:
         realtime_parking_site_inputs: list[RealtimeParkingSiteInput] = []

--- a/src/parkapi_sources/converters/esslingen/validator.py
+++ b/src/parkapi_sources/converters/esslingen/validator.py
@@ -118,6 +118,7 @@ class EsslingenParkingSiteFeatureInput:
         static_parking_site_input = StaticParkingSiteInput(
             uid=str(self.properties.fid),
             name=str(self.properties.fid),
+            purpose=PurposeType.CAR,
             type=ParkingSiteType.ON_STREET,
             lat=round_7d(center.y),
             lon=round_7d(center.x),

--- a/src/parkapi_sources/converters/freiburg/converter.py
+++ b/src/parkapi_sources/converters/freiburg/converter.py
@@ -10,7 +10,13 @@ from validataclass.validators import DataclassValidator
 
 from parkapi_sources.converters.base_converter.pull import ParkingSitePullConverter, StaticGeojsonDataMixin
 from parkapi_sources.exceptions import ImportParkingSiteException, ImportSourceException
-from parkapi_sources.models import GeojsonInput, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import (
+    GeojsonInput,
+    PurposeType,
+    RealtimeParkingSiteInput,
+    SourceInfo,
+    StaticParkingSiteInput,
+)
 
 from .models import (
     FreiburgBaseFeatureInput,
@@ -96,6 +102,7 @@ class FreiburgPullConverter(FreiburgBasePullConverter):
         static_parking_site_inputs, import_parking_site_exceptions = (
             self._get_static_parking_site_inputs_and_exceptions(
                 source_uid=self.source_info.uid,
+                purpose=PurposeType.CAR,
             )
         )
 

--- a/src/parkapi_sources/converters/freiburg/models.py
+++ b/src/parkapi_sources/converters/freiburg/models.py
@@ -113,6 +113,7 @@ class FreiburgParkAndRideStaticFeatureInput(FreiburgBaseFeatureInput):
             lat=round_7d(self.geometry.y),
             lon=round_7d(self.geometry.x),
             name=name,
+            purpose=PurposeType.CAR,
             capacity=self.properties.kapazitaet,
             type=self.properties.kategorie.to_parking_site_type_input(),
             static_data_updated_at=datetime.now(tz=timezone.utc),

--- a/src/parkapi_sources/converters/freiburg_scanner/validator.py
+++ b/src/parkapi_sources/converters/freiburg_scanner/validator.py
@@ -19,7 +19,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingSiteType
+from parkapi_sources.models.enums import ParkingSiteType, PurposeType
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import GeoJSONGeometryValidator
 
@@ -69,6 +69,7 @@ class FreiburgScannerFeatureInput:
         return StaticParkingSiteInput(
             uid=str(self.properties.id),
             name=self.properties.kr_strassenname,
+            purpose=PurposeType.CAR,
             address=f'{self.properties.kr_strassenname}, Freiburg',
             type=ParkingSiteType.ON_STREET,
             lat=round_7d(center.y),

--- a/src/parkapi_sources/converters/heidelberg/models.py
+++ b/src/parkapi_sources/converters/heidelberg/models.py
@@ -29,6 +29,7 @@ from parkapi_sources.models.enums import (
     ParkAndRideType,
     ParkingAudience,
     ParkingSiteType,
+    PurposeType,
     SupervisionType,
 )
 from parkapi_sources.validators import ExcelNoneable, ReplacingStringValidator, Rfc1123DateTimeValidator
@@ -185,6 +186,7 @@ class HeidelbergInput:
         static_parking_site_input = StaticParkingSiteInput(
             uid=self.id,
             name=self.staticName,
+            purpose=PurposeType.CAR,
             description=self.description,
             lat=self.lat,
             lon=self.lon,

--- a/src/parkapi_sources/converters/heidelberg_disabled/validator.py
+++ b/src/parkapi_sources/converters/heidelberg_disabled/validator.py
@@ -16,7 +16,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import ParkingSpotRestrictionInput, StaticParkingSpotInput
-from parkapi_sources.models.enums import ParkingAudience, ParkingSpotType
+from parkapi_sources.models.enums import ParkingAudience, ParkingSpotType, PurposeType
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import GeoJSONGeometryValidator
 
@@ -54,6 +54,7 @@ class HeidelbergDisabledParkingSpotInput:
         return StaticParkingSpotInput(
             uid=self.id,
             name=self.properties.BESCHRIFTU or None,
+            purpose=PurposeType.CAR,
             operator_name=self.properties.BETREIBER,
             address=f'{address}, Heidelberg' if address else None,
             static_data_updated_at=static_data_updated_at,

--- a/src/parkapi_sources/converters/heidelberg_easypark/validator.py
+++ b/src/parkapi_sources/converters/heidelberg_easypark/validator.py
@@ -20,7 +20,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingSiteOrientation, ParkingSiteSide, ParkingSiteType
+from parkapi_sources.models.enums import ParkingSiteOrientation, ParkingSiteSide, ParkingSiteType, PurposeType
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import (
     EmptystringNoneable,
@@ -121,6 +121,7 @@ class HeidelbergEasyParkParkingSiteInput:
         return StaticParkingSiteInput(
             uid=f'{self.properties.Segment}-{self.properties.Abstand1}-{self.properties.Abstand2}',
             name=self.properties.Strassenna or 'Parkplatz',
+            purpose=PurposeType.CAR,
             address=address,
             static_data_updated_at=static_data_updated_at,
             type=ParkingSiteType.ON_STREET,

--- a/src/parkapi_sources/converters/herrenberg/models.py
+++ b/src/parkapi_sources/converters/herrenberg/models.py
@@ -22,7 +22,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import ParkingSiteRestrictionInput, RealtimeParkingSiteInput, StaticParkingSiteInput
-from parkapi_sources.models.enums import OpeningStatus, ParkAndRideType, ParkingAudience, ParkingSiteType
+from parkapi_sources.models.enums import OpeningStatus, ParkAndRideType, ParkingAudience, ParkingSiteType, PurposeType
 from parkapi_sources.validators import OsmOpeningTimesValidator
 
 
@@ -115,6 +115,7 @@ class HerrenbergParkingSiteInput:
         static_parking_site_input = StaticParkingSiteInput(
             uid=self.id,
             name=self.name,
+            purpose=PurposeType.CAR,
             lat=self.coords.lat,
             lon=self.coords.lng,
             operator_name='Stadt Herrenberg',

--- a/src/parkapi_sources/converters/herrenberg_bike/converter.py
+++ b/src/parkapi_sources/converters/herrenberg_bike/converter.py
@@ -10,7 +10,12 @@ from validataclass.validators import DataclassValidator
 
 from parkapi_sources.converters.base_converter.pull import ParkingSitePullConverter
 from parkapi_sources.exceptions import ImportParkingSiteException, ImportSourceException
-from parkapi_sources.models import GeojsonInput, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import (
+    GeojsonInput,
+    RealtimeParkingSiteInput,
+    SourceInfo,
+    StaticParkingSiteInput,
+)
 
 from .models import HerrenbergBikeFeatureInput
 

--- a/src/parkapi_sources/converters/herrenberg_bike/models.py
+++ b/src/parkapi_sources/converters/herrenberg_bike/models.py
@@ -18,7 +18,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import GeojsonBaseFeatureInput, StaticParkingSiteInput
-from parkapi_sources.models.enums import ExternalIdentifierType, ParkingAudience, ParkingSiteType
+from parkapi_sources.models.enums import ExternalIdentifierType, ParkingAudience, ParkingSiteType, PurposeType
 from parkapi_sources.models.parking_site_inputs import ParkingSiteRestrictionInput
 from parkapi_sources.models.shared_inputs import ExternalIdentifierInput
 from parkapi_sources.util import round_7d
@@ -126,6 +126,7 @@ class HerrenbergBikeFeatureInput(GeojsonBaseFeatureInput):
         return StaticParkingSiteInput(
             lat=round_7d(self.geometry.y),
             lon=round_7d(self.geometry.x),
+            purpose=PurposeType.BIKE,
             has_realtime_data=False,
             **self.properties.to_dict(),
         )

--- a/src/parkapi_sources/converters/karlsruhe/models.py
+++ b/src/parkapi_sources/converters/karlsruhe/models.py
@@ -92,6 +92,7 @@ class KarlsruheFeatureInput(GeojsonBaseFeatureInput):
             lat=round_7d(self.geometry.y),
             lon=round_7d(self.geometry.x),
             name=self.properties.parkhaus_name,
+            purpose=PurposeType.CAR,
             capacity=self.properties.gesamte_parkplaetze,
             type=ParkingSiteType.CAR_PARK,
             address=address,

--- a/src/parkapi_sources/converters/karlsruhe_disabled/models.py
+++ b/src/parkapi_sources/converters/karlsruhe_disabled/models.py
@@ -24,6 +24,7 @@ from parkapi_sources.models import (
     ParkingAudience,
     ParkingSpotRestrictionInput,
     ParkingSpotStatus,
+    PurposeType,
     RealtimeParkingSpotInput,
     StaticParkingSpotInput,
 )
@@ -91,6 +92,7 @@ class KarlsruheDisabledFeatureInput(GeojsonBaseFeatureInput):
                 StaticParkingSpotInput(
                     uid=f'{self.properties.id}_{i}',
                     name=item_name,
+                    purpose=PurposeType.CAR,
                     address=f'{self.properties.standort}, {self.properties.gemeinde}',
                     static_data_updated_at=self.properties.stand,
                     description=', '.join(description for description in descriptions if description),

--- a/src/parkapi_sources/converters/keltern/validator.py
+++ b/src/parkapi_sources/converters/keltern/validator.py
@@ -15,6 +15,7 @@ from parkapi_sources.models import (
     ParkingAudience,
     ParkingSiteRestrictionInput,
     ParkingSiteType,
+    PurposeType,
     StaticParkingSiteInput,
 )
 from parkapi_sources.models.xlsx_inputs import ExcelMappedBooleanValidator
@@ -69,6 +70,7 @@ class KelternRowInput:
             uid=self.id.replace('@GemeindeKeltern', ''),
             capacity=self.capacity,
             name=self.adress_str,
+            purpose=PurposeType.CAR,
             opening_hours='24/7' if self.hasOpeningHours24h else None,
             description='; '.join(description_fragments),
             address=f'{self.adress_str}, {self.adress_pos} {self.adress_cit}',

--- a/src/parkapi_sources/converters/konstanz/models.py
+++ b/src/parkapi_sources/converters/konstanz/models.py
@@ -26,7 +26,7 @@ from parkapi_sources.converters.konstanz.validators import (
     NumericIntegerValidator,
 )
 from parkapi_sources.models import ParkingSiteRestrictionInput, RealtimeParkingSiteInput, StaticParkingSiteInput
-from parkapi_sources.models.enums import OpeningStatus, ParkingAudience, ParkingSiteType
+from parkapi_sources.models.enums import OpeningStatus, ParkingAudience, ParkingSiteType, PurposeType
 from parkapi_sources.validators import (
     EmptystringNoneable,
     GermanDurationIntegerValidator,
@@ -116,6 +116,7 @@ class KonstanzParkingSiteDataInput:
         return StaticParkingSiteInput(
             uid=str(self.id),
             name=self.name,
+            purpose=PurposeType.CAR,
             operator_name=self.operator,
             public_url=self.public_url,
             address=self.address,

--- a/src/parkapi_sources/converters/konstanz_bike/models.py
+++ b/src/parkapi_sources/converters/konstanz_bike/models.py
@@ -14,7 +14,7 @@ from validataclass.dataclasses import validataclass
 from validataclass.validators import DataclassValidator, EnumValidator, IntegerValidator, Noneable, StringValidator
 
 from parkapi_sources.models import StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingSiteType
+from parkapi_sources.models.enums import ParkingSiteType, PurposeType
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import EmptystringNoneable, GeoJSONGeometryValidator
 
@@ -79,6 +79,7 @@ class KonstanzBikeParkingSiteInput:
         static_parking_site_input = StaticParkingSiteInput(
             uid=str(self.properties.OBJECTID),
             name=name,
+            purpose=PurposeType.BIKE,
             type=self.properties.Art.to_parking_site_type_input(),
             is_covered=True if self.properties.Ueberdachung == UeberdachungProperty.true else False,
             has_lighting=True if self.properties.Beleuchtung == BeleuchtungProperty.true else False,

--- a/src/parkapi_sources/converters/konstanz_disabled/models.py
+++ b/src/parkapi_sources/converters/konstanz_disabled/models.py
@@ -15,6 +15,7 @@ from parkapi_sources.models import (
     GeojsonBaseFeatureInput,
     ParkingAudience,
     ParkingSpotRestrictionInput,
+    PurposeType,
     StaticParkingSpotInput,
 )
 from parkapi_sources.util import generate_point, round_7d
@@ -65,6 +66,7 @@ class KonstanzDisabledFeatureInput(GeojsonBaseFeatureInput):
                 StaticParkingSpotInput(
                     uid=f'{self.properties.GlobalID}_{i}',
                     name=f'{self.properties.Name} {i + 1} / {self.properties.Informatio}',
+                    purpose=PurposeType.CAR,
                     static_data_updated_at=datetime.now(tz=timezone.utc),
                     lat=lat,
                     lon=lon,

--- a/src/parkapi_sources/converters/ladenburg_parkraumcheck/validator.py
+++ b/src/parkapi_sources/converters/ladenburg_parkraumcheck/validator.py
@@ -26,7 +26,7 @@ from parkapi_sources.models import (
     ParkingSiteRestrictionInput,
     StaticParkingSiteInput,
 )
-from parkapi_sources.models.enums import ParkingSiteOrientation, ParkingSiteSide, ParkingSiteType
+from parkapi_sources.models.enums import ParkingSiteOrientation, ParkingSiteSide, ParkingSiteType, PurposeType
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import (
     GeoJSONGeometryValidator,
@@ -119,6 +119,7 @@ class LadenburgParkraumcheckParkingSiteInput:
         return StaticParkingSiteInput(
             uid=str(self.properties.fid),
             name=self.properties.Adresse,
+            purpose=PurposeType.CAR,
             address=f'{self.properties.Adresse}, {self.properties.Ort}',
             static_data_updated_at=static_data_updated_at,
             type=ParkingSiteType.ON_STREET,

--- a/src/parkapi_sources/converters/mannheim_buchen/converter.py
+++ b/src/parkapi_sources/converters/mannheim_buchen/converter.py
@@ -3,11 +3,21 @@ Copyright 2024 binary butterfly GmbH
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
 """
 
+from validataclass.dataclasses import Default, validataclass
+from validataclass.validators import DataclassValidator
+
 from parkapi_sources.converters.base_converter.push import ParkApiConverter
-from parkapi_sources.models import SourceInfo
+from parkapi_sources.models import PurposeType, SourceInfo, StaticParkingSiteInput
+
+
+@validataclass
+class MannheimStaticParkingSiteInput(StaticParkingSiteInput):
+    purpose: PurposeType = Default(PurposeType.CAR)
 
 
 class MannheimPushConverter(ParkApiConverter):
+    static_parking_site_validator = DataclassValidator(MannheimStaticParkingSiteInput)
+
     source_info = SourceInfo(
         uid='mannheim',
         name='Stadt Mannheim',
@@ -18,6 +28,8 @@ class MannheimPushConverter(ParkApiConverter):
 
 
 class BuchenPushConverter(ParkApiConverter):
+    static_parking_site_validator = DataclassValidator(MannheimStaticParkingSiteInput)
+
     source_info = SourceInfo(
         uid='buchen',
         name='Stadt Buchen',

--- a/src/parkapi_sources/converters/neckarsulm/models.py
+++ b/src/parkapi_sources/converters/neckarsulm/models.py
@@ -12,7 +12,7 @@ from validataclass.dataclasses import validataclass
 from validataclass.validators import DecimalValidator, EnumValidator, IntegerValidator, StringValidator
 
 from parkapi_sources.models import ParkingSiteRestrictionInput, StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingAudience, ParkingSiteType
+from parkapi_sources.models.enums import ParkingAudience, ParkingSiteType, PurposeType
 from parkapi_sources.validators import ExcelNoneable
 from parkapi_sources.validators.boolean_validators import MappedBooleanValidator
 
@@ -92,6 +92,7 @@ class NeckarsulmRowInput:
         return StaticParkingSiteInput(
             uid=str(self.uid),
             name=self.name,
+            purpose=PurposeType.CAR,
             type=self.type.to_parking_site_type_input(),
             lat=self.lat,
             lon=self.lon,

--- a/src/parkapi_sources/converters/p_m_bw/converter.py
+++ b/src/parkapi_sources/converters/p_m_bw/converter.py
@@ -11,7 +11,7 @@ from parkapi_sources.converters.base_converter.pull import (
     StaticGeojsonDataMixin,
 )
 from parkapi_sources.exceptions import ImportParkingSiteException
-from parkapi_sources.models import RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import PurposeType, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
 
 from .models import PMBWInput
 
@@ -34,6 +34,7 @@ class PMBWPullConverter(ParkingSitePullConverter, StaticGeojsonDataMixin):
 
         geojson_parking_site_inputs, geojson_parking_site_errors = self._get_static_parking_site_inputs_and_exceptions(
             source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
         )
 
         static_parking_site_errors += geojson_parking_site_errors

--- a/src/parkapi_sources/converters/p_m_bw/models.py
+++ b/src/parkapi_sources/converters/p_m_bw/models.py
@@ -18,7 +18,7 @@ from validataclass.validators import (
 )
 
 from parkapi_sources.models import ParkingSiteRestrictionInput, RealtimeParkingSiteInput, StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkAndRideType, ParkingAudience, ParkingSiteType
+from parkapi_sources.models.enums import ParkAndRideType, ParkingAudience, ParkingSiteType, PurposeType
 from parkapi_sources.validators import SpacedDateTimeValidator
 
 
@@ -67,6 +67,7 @@ class PMBWInput:
         return StaticParkingSiteInput(
             uid=self.id,
             name=self.long_name,
+            purpose=PurposeType.CAR,
             static_data_updated_at=self.time,
             capacity=self.capacity.car,
             has_realtime_data=True,

--- a/src/parkapi_sources/converters/pbw/mapper.py
+++ b/src/parkapi_sources/converters/pbw/mapper.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from parkapi_sources.models import (
     ParkingAudience,
     ParkingSiteRestrictionInput,
+    PurposeType,
     RealtimeParkingSiteInput,
     StaticParkingSiteInput,
 )
@@ -25,6 +26,7 @@ class PbwMapper:
         static_parking_site_input = StaticParkingSiteInput(
             uid=str(parking_site_detail_input.id),
             name=parking_site_detail_input.objekt.name,
+            purpose=PurposeType.CAR,
             operator_name='Parkraumgesellschaft Baden-Württemberg mbH',
             public_url=f'https://www.pbw.de/?menu=parkplatz-finder&search=*{str(parking_site_detail_input.id)}',
             static_data_updated_at=datetime.now(tz=timezone.utc),

--- a/src/parkapi_sources/converters/pforzheim/converter.py
+++ b/src/parkapi_sources/converters/pforzheim/converter.py
@@ -12,7 +12,7 @@ from parkapi_sources.converters.base_converter import ParkingSiteBaseConverter
 from parkapi_sources.converters.base_converter.push import JsonConverter
 from parkapi_sources.exceptions import ImportParkingSiteException
 from parkapi_sources.models import ParkingSiteRestrictionInput, SourceInfo, StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingAudience, SupervisionType
+from parkapi_sources.models.enums import ParkingAudience, PurposeType, SupervisionType
 
 from .validation import PforzheimInput
 
@@ -47,6 +47,7 @@ class PforzheimPushConverter(JsonConverter, ParkingSiteBaseConverter):
             parking_site_input = StaticParkingSiteInput(
                 uid=input_data.Id,
                 name=input_data.name,
+                purpose=PurposeType.CAR,
                 type=input_data.type.to_parking_site_type_input(),
                 lat=input_data.lat,
                 lon=input_data.lon,

--- a/src/parkapi_sources/converters/pum_bw/converter.py
+++ b/src/parkapi_sources/converters/pum_bw/converter.py
@@ -14,7 +14,7 @@ from validataclass.exceptions import ValidationError
 from parkapi_sources.converters.base_converter import ParkingSiteBaseConverter
 from parkapi_sources.converters.base_converter.push import XlsxConverter
 from parkapi_sources.exceptions import ImportParkingSiteException
-from parkapi_sources.models import SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import PurposeType, SourceInfo, StaticParkingSiteInput
 
 
 class PumBwPushConverter(XlsxConverter, ParkingSiteBaseConverter):
@@ -85,6 +85,7 @@ class PumBwPushConverter(XlsxConverter, ParkingSiteBaseConverter):
             )
 
         parking_site_dict['type'] = 'OFF_STREET_PARKING_GROUND'
+        parking_site_dict['purpose'] = PurposeType.CAR.name
         parking_site_dict['park_and_ride_type'] = ['CARPOOL']
         parking_site_dict['static_data_updated_at'] = datetime.now(tz=timezone.utc).isoformat()
         parking_site_dict['capacity'] = int(parking_site_dict['capacity'])

--- a/src/parkapi_sources/converters/radolfzell/validator.py
+++ b/src/parkapi_sources/converters/radolfzell/validator.py
@@ -34,6 +34,7 @@ from parkapi_sources.models.enums import (
     ParkingSiteOrientation,
     ParkingSiteType,
     ParkingType,
+    PurposeType,
 )
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import (
@@ -175,6 +176,7 @@ class RadolfzellParkingSiteInput:
         static_parking_site_input = StaticParkingSiteInput(
             uid=f'{self.properties.lat}_{self.properties.lon}',
             name=self.properties.StrPLZOrt2 or 'Parkplatz',
+            purpose=PurposeType.CAR,
             address=self.properties.StrPLZOrt2,
             static_data_updated_at=static_data_updated_at,
             type=ParkingSiteType.ON_STREET,

--- a/src/parkapi_sources/converters/reutlingen/validation.py
+++ b/src/parkapi_sources/converters/reutlingen/validation.py
@@ -10,7 +10,7 @@ from validataclass.dataclasses import validataclass
 from validataclass.validators import DecimalValidator, EnumValidator, IntegerValidator, StringValidator
 
 from parkapi_sources.models import StaticParkingSiteInput
-from parkapi_sources.models.enums import ParkingSiteType
+from parkapi_sources.models.enums import ParkingSiteType, PurposeType
 from parkapi_sources.validators import PointCoordinateTupleValidator
 
 
@@ -40,6 +40,7 @@ class ReutlingenRowInput:
         return StaticParkingSiteInput(
             uid=str(self.uid),
             name=self.name,
+            purpose=PurposeType.CAR,
             address=f'{self.name}, Reutlingen',
             lat=self.coordinates[1],
             lon=self.coordinates[0],

--- a/src/parkapi_sources/converters/ulm/converter.py
+++ b/src/parkapi_sources/converters/ulm/converter.py
@@ -14,7 +14,7 @@ from parkapi_sources.converters.base_converter.pull import (
     StaticGeojsonDataMixin,
 )
 from parkapi_sources.exceptions import ImportParkingSiteException
-from parkapi_sources.models import RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
+from parkapi_sources.models import PurposeType, RealtimeParkingSiteInput, SourceInfo, StaticParkingSiteInput
 
 
 class UlmPullConverter(ParkingSitePullConverter, StaticGeojsonDataMixin, PullScraperMixin):
@@ -29,7 +29,10 @@ class UlmPullConverter(ParkingSitePullConverter, StaticGeojsonDataMixin, PullScr
     )
 
     def get_static_parking_sites(self) -> tuple[list[StaticParkingSiteInput], list[ImportParkingSiteException]]:
-        return self._get_static_parking_site_inputs_and_exceptions(source_uid=self.source_info.uid)
+        return self._get_static_parking_site_inputs_and_exceptions(
+            source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
+        )
 
     def get_realtime_parking_sites(self) -> tuple[list[RealtimeParkingSiteInput], list[ImportParkingSiteException]]:
         return self._get_scraped_realtime_parking_site_inputs_and_exceptions()

--- a/src/parkapi_sources/converters/ulm_sensors/converter.py
+++ b/src/parkapi_sources/converters/ulm_sensors/converter.py
@@ -13,6 +13,7 @@ from parkapi_sources.converters.base_converter.pull import (
 )
 from parkapi_sources.exceptions import ImportParkingSiteException, ImportParkingSpotException
 from parkapi_sources.models import (
+    PurposeType,
     RealtimeParkingSiteInput,
     RealtimeParkingSpotInput,
     SourceInfo,
@@ -44,6 +45,7 @@ class UlmSensorsPullConverter(ParkingSpotPullConverter, ParkingSitePullConverter
     def get_static_parking_sites(self) -> tuple[list[StaticParkingSiteInput], list[ImportParkingSiteException]]:
         return self._get_static_parking_site_inputs_and_exceptions(
             source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
         )
 
     def get_realtime_parking_sites(self) -> tuple[list[RealtimeParkingSiteInput], list[ImportParkingSiteException]]:
@@ -87,6 +89,7 @@ class UlmSensorsPullConverter(ParkingSpotPullConverter, ParkingSitePullConverter
     def get_static_parking_spots(self) -> tuple[list[StaticParkingSpotInput], list[ImportParkingSpotException]]:
         return self._get_static_parking_spots_inputs_and_exceptions(
             source_uid=self.source_info.uid,
+            purpose=PurposeType.CAR,
         )
 
     def get_realtime_parking_spots(self) -> tuple[list[RealtimeParkingSpotInput], list[ImportParkingSpotException]]:

--- a/src/parkapi_sources/models/base_parking_inputs.py
+++ b/src/parkapi_sources/models/base_parking_inputs.py
@@ -31,7 +31,7 @@ from .shared_inputs import ExternalIdentifierInput, ParkingRestrictionInput
 class StaticBaseParkingInput(ValidataclassMixin, ABC):
     uid: str = StringValidator(min_length=1, max_length=256)
 
-    purpose: PurposeType = EnumValidator(PurposeType), Default(PurposeType.CAR)
+    purpose: PurposeType = EnumValidator(PurposeType)
     address: str | None = Noneable(StringValidator(max_length=512)), Default(None)
     description: str | None = Noneable(StringValidator(max_length=4096)), Default(None)
     operator_name: str | None = Noneable(StringValidator(max_length=256)), Default(None)

--- a/src/parkapi_sources/models/geojson_inputs.py
+++ b/src/parkapi_sources/models/geojson_inputs.py
@@ -23,7 +23,7 @@ from validataclass.validators import (
 from parkapi_sources.util import round_7d
 from parkapi_sources.validators import GeoJSONGeometryValidator, OsmOpeningTimesValidator
 
-from .enums import ParkAndRideType, ParkingSiteType
+from .enums import ParkAndRideType, ParkingSiteType, PurposeType
 from .parking_site_inputs import ParkingSiteRestrictionInput, StaticParkingSiteInput
 from .parking_spot_inputs import ParkingSpotRestrictionInput, StaticParkingSpotInput
 from .shared_inputs import ExternalIdentifierInput
@@ -81,7 +81,7 @@ class GeojsonBaseFeatureInput:
     properties: GeojsonBaseFeaturePropertiesInput = DataclassValidator(GeojsonBaseFeaturePropertiesInput)
     geometry: Point = GeoJSONGeometryValidator(allowed_geometry_types=[GeometryType.POINT])
 
-    def to_static_parking_site_input(self, **kwargs: Any) -> StaticParkingSiteInput:
+    def to_static_parking_site_input(self, purpose: PurposeType, **kwargs: Any) -> StaticParkingSiteInput:
         # Maintain child objects by not using to_dict()
         input_data: dict[str, Any] = {key: getattr(self.properties, key) for key in self.properties.to_dict().keys()}
         input_data.update(kwargs)
@@ -89,10 +89,11 @@ class GeojsonBaseFeatureInput:
         return StaticParkingSiteInput(
             lat=round_7d(self.geometry.y),
             lon=round_7d(self.geometry.x),
+            purpose=purpose,
             **input_data,
         )
 
-    def to_static_parking_spot_input(self, **kwargs: Any) -> StaticParkingSpotInput:
+    def to_static_parking_spot_input(self, purpose: PurposeType, **kwargs: Any) -> StaticParkingSpotInput:
         # Maintain child objects by not using to_dict()
         input_data: dict[str, Any] = {key: getattr(self.properties, key) for key in self.properties.to_dict().keys()}
         input_data.update(kwargs)
@@ -100,6 +101,7 @@ class GeojsonBaseFeatureInput:
         return StaticParkingSpotInput(
             lat=round_7d(self.geometry.y),
             lon=round_7d(self.geometry.x),
+            purpose=purpose,
             **input_data,
         )
 

--- a/tests/converters/mannheim_buchen_test.py
+++ b/tests/converters/mannheim_buchen_test.py
@@ -23,7 +23,7 @@ def mannheim_push_converter(mocked_config_helper: Mock, request_helper: RequestH
     return MannheimPushConverter(config_helper=mocked_config_helper, request_helper=request_helper)
 
 
-class MannheimPullConverterTest:
+class MannheimPushConverterTest:
     @staticmethod
     def test_get_parking_sites(mannheim_push_converter: MannheimPushConverter):
         # TODO: set proper test files as soon as we get them


### PR DESCRIPTION
enforces purpose

@AbdullahiFatola this is a kind of breaking MR, as it enforces a new value to be set. At mannheim and buchen as well as at any generic source in ParkAPI, I would add a compatibility layer, but this should not be active forever. Can you check all generic data sources and ask them to add purpose?

Also, we should move mannheim and buchen to a generic data source in the future, as they speak ParkAPI. The concept of a generic data source did not exist in early days, but now it does.